### PR TITLE
feat: add skeleton for python, nodejs, and java demo apps

### DIFF
--- a/apps/README.md
+++ b/apps/README.md
@@ -1,0 +1,21 @@
+# Demo Applications
+
+This directory contains three independent demo applications, each built on a
+base image copied from Docker Hub and deployed to a highly scalable Kubernetes
+cluster via Helm.
+
+| App | Language | Build tool | Folder |
+| --- | -------- | ---------- | ------ |
+| Python web app | Python | pip | [`python-app/`](python-app/) |
+| Node.js web app | Node.js | npm | [`nodejs-app/`](nodejs-app/) |
+| Java web app | Java | Gradle | [`java-app/`](java-app/) |
+
+Each application is self-contained and includes:
+
+- Source code using language-native conventions
+- A `Dockerfile` that builds on a configurable base image
+- A Helm chart under `deploy/helm/` with scalable Kubernetes resources
+  (Deployment, Service, Ingress, HorizontalPodAutoscaler, PodDisruptionBudget,
+  ConfigMap)
+
+> Note: This is a structural skeleton. Files are placeholders to be filled in.

--- a/apps/java-app/.dockerignore
+++ b/apps/java-app/.dockerignore
@@ -1,0 +1,3 @@
+.git
+.gradle/
+build/

--- a/apps/java-app/Dockerfile
+++ b/apps/java-app/Dockerfile
@@ -1,0 +1,6 @@
+# TODO: Define the build for the Java demo app.
+# Use a configurable base image copied from Docker Hub.
+ARG BASE_IMAGE=eclipse-temurin:21-jre
+FROM ${BASE_IMAGE}
+
+# Placeholder Dockerfile — fill in build/run steps.

--- a/apps/java-app/README.md
+++ b/apps/java-app/README.md
@@ -1,0 +1,11 @@
+# Java Demo App
+
+Simple Java web application for demo purposes.
+
+- **Build tool:** Gradle (Kotlin DSL)
+- **Language convention:** standard `src/main/java`, `src/main/resources`,
+  `src/test/java` layout
+- **Base image:** configurable Docker Hub base image (see `Dockerfile`)
+- **Deployment:** Helm chart under [`deploy/helm/`](deploy/helm/)
+
+> Placeholder skeleton — fill in implementation details.

--- a/apps/java-app/build.gradle.kts
+++ b/apps/java-app/build.gradle.kts
@@ -1,0 +1,20 @@
+// TODO: Configure the Gradle build for the Java demo app.
+// Placeholder build script (Kotlin DSL).
+
+plugins {
+    java
+    application
+}
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    // TODO: Add web framework dependencies (e.g., Spring Boot or Javalin).
+}
+
+application {
+    // TODO: Set the main class.
+    // mainClass.set("com.example.demo.App")
+}

--- a/apps/java-app/deploy/helm/.helmignore
+++ b/apps/java-app/deploy/helm/.helmignore
@@ -1,0 +1,3 @@
+# Default ignores for Helm chart packaging.
+.git
+*.tgz

--- a/apps/java-app/deploy/helm/Chart.yaml
+++ b/apps/java-app/deploy/helm/Chart.yaml
@@ -1,0 +1,7 @@
+apiVersion: v2
+name: java-app
+description: Helm chart for the Java demo web application
+type: application
+version: 0.1.0
+appVersion: "0.1.0"
+# TODO: Adjust metadata as needed.

--- a/apps/java-app/deploy/helm/templates/_helpers.tpl
+++ b/apps/java-app/deploy/helm/templates/_helpers.tpl
@@ -1,0 +1,1 @@
+{{/* TODO: Define common template helpers (name, fullname, labels). */}}

--- a/apps/java-app/deploy/helm/templates/configmap.yaml
+++ b/apps/java-app/deploy/helm/templates/configmap.yaml
@@ -1,0 +1,1 @@
+# TODO: ConfigMap manifest (from .Values.config).

--- a/apps/java-app/deploy/helm/templates/deployment.yaml
+++ b/apps/java-app/deploy/helm/templates/deployment.yaml
@@ -1,0 +1,1 @@
+# TODO: Deployment manifest (replicas, container, probes, resources).

--- a/apps/java-app/deploy/helm/templates/hpa.yaml
+++ b/apps/java-app/deploy/helm/templates/hpa.yaml
@@ -1,0 +1,1 @@
+# TODO: HorizontalPodAutoscaler manifest (gated by .Values.autoscaling.enabled).

--- a/apps/java-app/deploy/helm/templates/ingress.yaml
+++ b/apps/java-app/deploy/helm/templates/ingress.yaml
@@ -1,0 +1,1 @@
+# TODO: Ingress manifest (gated by .Values.ingress.enabled).

--- a/apps/java-app/deploy/helm/templates/pdb.yaml
+++ b/apps/java-app/deploy/helm/templates/pdb.yaml
@@ -1,0 +1,1 @@
+# TODO: PodDisruptionBudget manifest (gated by .Values.podDisruptionBudget.enabled).

--- a/apps/java-app/deploy/helm/templates/service.yaml
+++ b/apps/java-app/deploy/helm/templates/service.yaml
@@ -1,0 +1,1 @@
+# TODO: Service manifest.

--- a/apps/java-app/deploy/helm/values.yaml
+++ b/apps/java-app/deploy/helm/values.yaml
@@ -1,0 +1,39 @@
+# Placeholder values for the Java demo app Helm chart.
+# TODO: Tune for your environment.
+
+replicaCount: 2
+
+image:
+  repository: REPLACE_ME/java-app
+  tag: latest
+  pullPolicy: IfNotPresent
+
+service:
+  type: ClusterIP
+  port: 80
+  targetPort: 8080
+
+ingress:
+  enabled: false
+  className: ""
+  hosts: []
+
+resources:
+  requests:
+    cpu: 250m
+    memory: 256Mi
+  limits:
+    cpu: 1000m
+    memory: 512Mi
+
+autoscaling:
+  enabled: true
+  minReplicas: 2
+  maxReplicas: 10
+  targetCPUUtilizationPercentage: 70
+
+podDisruptionBudget:
+  enabled: true
+  minAvailable: 1
+
+config: {}

--- a/apps/java-app/settings.gradle.kts
+++ b/apps/java-app/settings.gradle.kts
@@ -1,0 +1,2 @@
+// TODO: Configure project settings.
+rootProject.name = "java-app"

--- a/apps/java-app/src/main/java/com/example/demo/App.java
+++ b/apps/java-app/src/main/java/com/example/demo/App.java
@@ -1,0 +1,6 @@
+// TODO: Implement the Java web application entrypoint.
+package com.example.demo;
+
+public class App {
+    // Placeholder for the demo web app.
+}

--- a/apps/java-app/src/main/resources/application.properties
+++ b/apps/java-app/src/main/resources/application.properties
@@ -1,0 +1,1 @@
+# TODO: Application configuration (e.g., application.properties values).

--- a/apps/java-app/src/test/java/com/example/demo/AppTest.java
+++ b/apps/java-app/src/test/java/com/example/demo/AppTest.java
@@ -1,0 +1,5 @@
+// TODO: Add tests for the Java demo app.
+package com.example.demo;
+
+public class AppTest {
+}

--- a/apps/nodejs-app/.dockerignore
+++ b/apps/nodejs-app/.dockerignore
@@ -1,0 +1,4 @@
+.git
+node_modules/
+npm-debug.log
+test/

--- a/apps/nodejs-app/Dockerfile
+++ b/apps/nodejs-app/Dockerfile
@@ -1,0 +1,6 @@
+# TODO: Define the build for the Node.js demo app.
+# Use a configurable base image copied from Docker Hub.
+ARG BASE_IMAGE=node:22-slim
+FROM ${BASE_IMAGE}
+
+# Placeholder Dockerfile — fill in build/run steps.

--- a/apps/nodejs-app/README.md
+++ b/apps/nodejs-app/README.md
@@ -1,0 +1,9 @@
+# Node.js Demo App
+
+Simple Node.js web application for demo purposes.
+
+- **Language convention:** `src/` with `package.json`, tests under `test/`
+- **Base image:** configurable Docker Hub base image (see `Dockerfile`)
+- **Deployment:** Helm chart under [`deploy/helm/`](deploy/helm/)
+
+> Placeholder skeleton — fill in implementation details.

--- a/apps/nodejs-app/deploy/helm/.helmignore
+++ b/apps/nodejs-app/deploy/helm/.helmignore
@@ -1,0 +1,3 @@
+# Default ignores for Helm chart packaging.
+.git
+*.tgz

--- a/apps/nodejs-app/deploy/helm/Chart.yaml
+++ b/apps/nodejs-app/deploy/helm/Chart.yaml
@@ -1,0 +1,7 @@
+apiVersion: v2
+name: nodejs-app
+description: Helm chart for the Node.js demo web application
+type: application
+version: 0.1.0
+appVersion: "0.1.0"
+# TODO: Adjust metadata as needed.

--- a/apps/nodejs-app/deploy/helm/templates/_helpers.tpl
+++ b/apps/nodejs-app/deploy/helm/templates/_helpers.tpl
@@ -1,0 +1,1 @@
+{{/* TODO: Define common template helpers (name, fullname, labels). */}}

--- a/apps/nodejs-app/deploy/helm/templates/configmap.yaml
+++ b/apps/nodejs-app/deploy/helm/templates/configmap.yaml
@@ -1,0 +1,1 @@
+# TODO: ConfigMap manifest (from .Values.config).

--- a/apps/nodejs-app/deploy/helm/templates/deployment.yaml
+++ b/apps/nodejs-app/deploy/helm/templates/deployment.yaml
@@ -1,0 +1,1 @@
+# TODO: Deployment manifest (replicas, container, probes, resources).

--- a/apps/nodejs-app/deploy/helm/templates/hpa.yaml
+++ b/apps/nodejs-app/deploy/helm/templates/hpa.yaml
@@ -1,0 +1,1 @@
+# TODO: HorizontalPodAutoscaler manifest (gated by .Values.autoscaling.enabled).

--- a/apps/nodejs-app/deploy/helm/templates/ingress.yaml
+++ b/apps/nodejs-app/deploy/helm/templates/ingress.yaml
@@ -1,0 +1,1 @@
+# TODO: Ingress manifest (gated by .Values.ingress.enabled).

--- a/apps/nodejs-app/deploy/helm/templates/pdb.yaml
+++ b/apps/nodejs-app/deploy/helm/templates/pdb.yaml
@@ -1,0 +1,1 @@
+# TODO: PodDisruptionBudget manifest (gated by .Values.podDisruptionBudget.enabled).

--- a/apps/nodejs-app/deploy/helm/templates/service.yaml
+++ b/apps/nodejs-app/deploy/helm/templates/service.yaml
@@ -1,0 +1,1 @@
+# TODO: Service manifest.

--- a/apps/nodejs-app/deploy/helm/values.yaml
+++ b/apps/nodejs-app/deploy/helm/values.yaml
@@ -1,0 +1,39 @@
+# Placeholder values for the Node.js demo app Helm chart.
+# TODO: Tune for your environment.
+
+replicaCount: 2
+
+image:
+  repository: REPLACE_ME/nodejs-app
+  tag: latest
+  pullPolicy: IfNotPresent
+
+service:
+  type: ClusterIP
+  port: 80
+  targetPort: 3000
+
+ingress:
+  enabled: false
+  className: ""
+  hosts: []
+
+resources:
+  requests:
+    cpu: 100m
+    memory: 128Mi
+  limits:
+    cpu: 500m
+    memory: 256Mi
+
+autoscaling:
+  enabled: true
+  minReplicas: 2
+  maxReplicas: 10
+  targetCPUUtilizationPercentage: 70
+
+podDisruptionBudget:
+  enabled: true
+  minAvailable: 1
+
+config: {}

--- a/apps/nodejs-app/package.json
+++ b/apps/nodejs-app/package.json
@@ -5,7 +5,7 @@
   "main": "src/server.js",
   "scripts": {
     "start": "node src/server.js",
-    "test": "echo \"TODO: add tests\" && exit 0"
+    "test": "echo \"Error: no tests configured yet\" && exit 1"
   },
-  "license": "MIT"
+  "license": "Apache-2.0"
 }

--- a/apps/nodejs-app/package.json
+++ b/apps/nodejs-app/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "nodejs-app",
+  "version": "0.1.0",
+  "description": "Node.js demo web application",
+  "main": "src/server.js",
+  "scripts": {
+    "start": "node src/server.js",
+    "test": "echo \"TODO: add tests\" && exit 0"
+  },
+  "license": "MIT"
+}

--- a/apps/nodejs-app/src/public/index.html
+++ b/apps/nodejs-app/src/public/index.html
@@ -1,0 +1,1 @@
+<!-- TODO: Static assets for the Node.js demo app. -->

--- a/apps/nodejs-app/src/server.js
+++ b/apps/nodejs-app/src/server.js
@@ -1,0 +1,2 @@
+// TODO: Implement the Node.js web application entrypoint.
+// Placeholder for the demo web app (e.g., Express).

--- a/apps/nodejs-app/test/server.test.js
+++ b/apps/nodejs-app/test/server.test.js
@@ -1,0 +1,1 @@
+// TODO: Add tests for the Node.js demo app.

--- a/apps/python-app/.dockerignore
+++ b/apps/python-app/.dockerignore
@@ -1,0 +1,5 @@
+.git
+**/__pycache__/
+*.pyc
+.venv/
+tests/

--- a/apps/python-app/Dockerfile
+++ b/apps/python-app/Dockerfile
@@ -1,0 +1,6 @@
+# TODO: Define the build for the Python demo app.
+# Use a configurable base image copied from Docker Hub.
+ARG BASE_IMAGE=python:3.12-slim
+FROM ${BASE_IMAGE}
+
+# Placeholder Dockerfile — fill in build/run steps.

--- a/apps/python-app/README.md
+++ b/apps/python-app/README.md
@@ -1,0 +1,9 @@
+# Python Demo App
+
+Simple Python web application for demo purposes.
+
+- **Language convention:** standard `src/` package layout with `tests/`
+- **Base image:** configurable Docker Hub base image (see `Dockerfile`)
+- **Deployment:** Helm chart under [`deploy/helm/`](deploy/helm/)
+
+> Placeholder skeleton — fill in implementation details.

--- a/apps/python-app/deploy/helm/.helmignore
+++ b/apps/python-app/deploy/helm/.helmignore
@@ -1,0 +1,3 @@
+# Default ignores for Helm chart packaging.
+.git
+*.tgz

--- a/apps/python-app/deploy/helm/Chart.yaml
+++ b/apps/python-app/deploy/helm/Chart.yaml
@@ -1,0 +1,7 @@
+apiVersion: v2
+name: python-app
+description: Helm chart for the Python demo web application
+type: application
+version: 0.1.0
+appVersion: "0.1.0"
+# TODO: Adjust metadata as needed.

--- a/apps/python-app/deploy/helm/templates/_helpers.tpl
+++ b/apps/python-app/deploy/helm/templates/_helpers.tpl
@@ -1,0 +1,1 @@
+{{/* TODO: Define common template helpers (name, fullname, labels). */}}

--- a/apps/python-app/deploy/helm/templates/configmap.yaml
+++ b/apps/python-app/deploy/helm/templates/configmap.yaml
@@ -1,0 +1,1 @@
+# TODO: ConfigMap manifest (from .Values.config).

--- a/apps/python-app/deploy/helm/templates/deployment.yaml
+++ b/apps/python-app/deploy/helm/templates/deployment.yaml
@@ -1,0 +1,1 @@
+# TODO: Deployment manifest (replicas, container, probes, resources).

--- a/apps/python-app/deploy/helm/templates/hpa.yaml
+++ b/apps/python-app/deploy/helm/templates/hpa.yaml
@@ -1,0 +1,1 @@
+# TODO: HorizontalPodAutoscaler manifest (gated by .Values.autoscaling.enabled).

--- a/apps/python-app/deploy/helm/templates/ingress.yaml
+++ b/apps/python-app/deploy/helm/templates/ingress.yaml
@@ -1,0 +1,1 @@
+# TODO: Ingress manifest (gated by .Values.ingress.enabled).

--- a/apps/python-app/deploy/helm/templates/pdb.yaml
+++ b/apps/python-app/deploy/helm/templates/pdb.yaml
@@ -1,0 +1,1 @@
+# TODO: PodDisruptionBudget manifest (gated by .Values.podDisruptionBudget.enabled).

--- a/apps/python-app/deploy/helm/templates/service.yaml
+++ b/apps/python-app/deploy/helm/templates/service.yaml
@@ -1,0 +1,1 @@
+# TODO: Service manifest.

--- a/apps/python-app/deploy/helm/values.yaml
+++ b/apps/python-app/deploy/helm/values.yaml
@@ -1,0 +1,39 @@
+# Placeholder values for the Python demo app Helm chart.
+# TODO: Tune for your environment.
+
+replicaCount: 2
+
+image:
+  repository: REPLACE_ME/python-app
+  tag: latest
+  pullPolicy: IfNotPresent
+
+service:
+  type: ClusterIP
+  port: 80
+  targetPort: 8080
+
+ingress:
+  enabled: false
+  className: ""
+  hosts: []
+
+resources:
+  requests:
+    cpu: 100m
+    memory: 128Mi
+  limits:
+    cpu: 500m
+    memory: 256Mi
+
+autoscaling:
+  enabled: true
+  minReplicas: 2
+  maxReplicas: 10
+  targetCPUUtilizationPercentage: 70
+
+podDisruptionBudget:
+  enabled: true
+  minAvailable: 1
+
+config: {}

--- a/apps/python-app/src/python_app/__init__.py
+++ b/apps/python-app/src/python_app/__init__.py
@@ -1,0 +1,1 @@
+"""Python demo web application package."""

--- a/apps/python-app/src/python_app/app.py
+++ b/apps/python-app/src/python_app/app.py
@@ -1,0 +1,2 @@
+# TODO: Implement the Python web application entrypoint.
+# Placeholder for the demo web app (e.g., Flask/FastAPI).

--- a/apps/python-app/src/requirements.txt
+++ b/apps/python-app/src/requirements.txt
@@ -1,0 +1,1 @@
+# TODO: Add Python dependencies (e.g., flask or fastapi).

--- a/apps/python-app/tests/test_app.py
+++ b/apps/python-app/tests/test_app.py
@@ -1,0 +1,1 @@
+# TODO: Add tests for the Python demo app.


### PR DESCRIPTION
Adds an `apps/` directory with three self-contained demo applications to support the [custos](https://github.com/toddysm/custos) workflow demos.

## Apps
| App | Language | Build tool |
| --- | -------- | ---------- |
| python-app | Python | pip |
| nodejs-app | Node.js | npm |
| java-app | Java | Gradle (Kotlin DSL) |

## Structure (per app)
- Language-native source layout + tests
- `Dockerfile` with a configurable `BASE_IMAGE` build arg + `.dockerignore`
- `README.md`
- Helm chart under `deploy/helm/` with templates for Deployment, Service, Ingress, HorizontalPodAutoscaler, PodDisruptionBudget, and ConfigMap

## Notes
- This is a **structure-only** skeleton; source and manifest files are placeholder stubs (TODO) to be implemented.
- `values.yaml` includes scalability defaults (replicas, HPA, PDB) ready to tune.