### PR TITLE
Mirror images into quarantine/ namespace instead of base/

### DIFF
--- a/.github/workflows/_mirror-image.yml
+++ b/.github/workflows/_mirror-image.yml
@@ -21,7 +21,7 @@ on:
         required: true
         type: string
       dest_image:
-        description: "Fully qualified destination image without tag (e.g. ghcr.io/toddysm/base/python)."
+        description: "Fully qualified destination image without tag (e.g. ghcr.io/toddysm/quarantine/python)."
         required: true
         type: string
       dest_tag:

--- a/.github/workflows/mirror-node.yml
+++ b/.github/workflows/mirror-node.yml
@@ -1,4 +1,4 @@
-# Mirror node:26-alpine from Docker Hub into GHCR as base/node.
+# Mirror node:26-alpine from Docker Hub into GHCR as quarantine/node.
 #
 # This caller only defines triggers and the image-specific inputs; the actual
 # digest-check-and-copy logic lives in the reusable _mirror-image.yml workflow.
@@ -6,7 +6,7 @@
 # Naming convention: "mirror-<image>.yml" for image mirror workflows, kept
 # separate from "build-<app>.yml" build workflows. See
 # docs/contributing/workflow-naming.md.
-name: mirror / base/node
+name: mirror / quarantine/node
 
 on:
   # Daily upstream check at 06:00 UTC.
@@ -23,7 +23,7 @@ on:
 
 # Avoid overlapping runs for this specific image mirror.
 concurrency:
-  group: mirror-base-node
+  group: mirror-quarantine-node
   cancel-in-progress: false
 
 permissions:
@@ -36,6 +36,6 @@ jobs:
     with:
       source_image: docker.io/library/node
       source_tag: 26-alpine
-      dest_image: ghcr.io/toddysm/base/node
+      dest_image: ghcr.io/toddysm/quarantine/node
       dest_tag: 26-alpine
       force: ${{ github.event_name == 'workflow_dispatch' && inputs.force || false }}

--- a/.github/workflows/mirror-python.yml
+++ b/.github/workflows/mirror-python.yml
@@ -1,4 +1,4 @@
-# Mirror python:3.14-slim from Docker Hub into GHCR as base/python.
+# Mirror python:3.14-slim from Docker Hub into GHCR as quarantine/python.
 #
 # This caller only defines triggers and the image-specific inputs; the actual
 # digest-check-and-copy logic lives in the reusable _mirror-image.yml workflow.
@@ -6,7 +6,7 @@
 # Naming convention: "mirror-<image>.yml" for image mirror workflows, kept
 # separate from "build-<app>.yml" build workflows. See
 # docs/contributing/workflow-naming.md.
-name: mirror / base/python
+name: mirror / quarantine/python
 
 on:
   # Daily upstream check at 06:00 UTC.
@@ -23,7 +23,7 @@ on:
 
 # Avoid overlapping runs for this specific image mirror.
 concurrency:
-  group: mirror-base-python
+  group: mirror-quarantine-python
   cancel-in-progress: false
 
 permissions:
@@ -36,6 +36,6 @@ jobs:
     with:
       source_image: docker.io/library/python
       source_tag: 3.14-slim
-      dest_image: ghcr.io/toddysm/base/python
+      dest_image: ghcr.io/toddysm/quarantine/python
       dest_tag: 3.14-slim
       force: ${{ github.event_name == 'workflow_dispatch' && inputs.force || false }}

--- a/docs/contributing/workflow-naming.md
+++ b/docs/contributing/workflow-naming.md
@@ -10,7 +10,7 @@ both in the file system and in the Actions UI.
 
 | Category | Purpose | Workflow file | Display `name:` | Concurrency group |
 | -------- | ------- | ------------- | --------------- | ----------------- |
-| **Mirror** | Copy / refresh a base image from an upstream registry into GHCR | `mirror-<image>.yml` | `mirror / base/<image>` | `mirror-base-<image>` |
+| **Mirror** | Copy / refresh a base image from an upstream registry into GHCR | `mirror-<image>.yml` | `mirror / quarantine/<image>` | `mirror-quarantine-<image>` |
 | **Build** | Build an application image on top of a mirrored base | `build-<app>.yml` | `build / <app>` | `build-<app>` |
 | **Reusable** | Shared logic invoked by other workflows; never triggered directly | `_<purpose>.yml` (leading underscore) | `_reusable / <purpose>` | n/a |
 
@@ -24,11 +24,11 @@ both in the file system and in the Actions UI.
    `workflow_call`) are prefixed with `_` so they sort to the top of the list
    and signal "do not run me directly."
 3. **Display names use a `category / subject` format** (for example
-   `mirror / base/python`) so the Actions sidebar reads cleanly.
+   `mirror / quarantine/python`) so the Actions sidebar reads cleanly.
 4. **Concurrency groups** mirror the filename so two runs of the same logical
    job never overlap, while different images/apps run independently.
 5. **GHCR destination repositories** for mirrored base images follow the
-   `base/<image>` scheme, e.g. `ghcr.io/<owner>/base/python`.
+   `quarantine/<image>` scheme, e.g. `ghcr.io/<owner>/quarantine/python`.
 
 ## Mirror workflows
 


### PR DESCRIPTION
Updates both mirror workflows to push into the `quarantine/` namespace instead of `base/`.

- `mirror-python.yml`: dest `ghcr.io/toddysm/quarantine/python:3.14-slim`
- `mirror-node.yml`: dest `ghcr.io/toddysm/quarantine/node:26-alpine`

Also updates workflow `name:`, header comments, and `concurrency` group names to match the new namespace. Source images and triggers are unchanged.

Note: new `quarantine/*` packages are created on first run (default private).