### PR TITLE
Add mirror workflow for openjdk:27-ea-slim into quarantine/openjdk

### DIFF
--- a/.github/workflows/mirror-openjdk.yml
+++ b/.github/workflows/mirror-openjdk.yml
@@ -1,0 +1,41 @@
+# Mirror openjdk:27-ea-slim from Docker Hub into GHCR as quarantine/openjdk.
+#
+# This caller only defines triggers and the image-specific inputs; the actual
+# digest-check-and-copy logic lives in the reusable _mirror-image.yml workflow.
+#
+# Naming convention: "mirror-<image>.yml" for image mirror workflows, kept
+# separate from "build-<app>.yml" build workflows. See
+# docs/contributing/workflow-naming.md.
+name: mirror / quarantine/openjdk
+
+on:
+  # Daily upstream check at 06:00 UTC.
+  schedule:
+    - cron: "0 6 * * *"
+  # Manual run, with an optional force copy.
+  workflow_dispatch:
+    inputs:
+      force:
+        description: "Copy even when the source and destination digests match."
+        required: false
+        default: false
+        type: boolean
+
+# Avoid overlapping runs for this specific image mirror.
+concurrency:
+  group: mirror-quarantine-openjdk
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  mirror-openjdk:
+    uses: ./.github/workflows/_mirror-image.yml
+    with:
+      source_image: docker.io/library/openjdk
+      source_tag: 27-ea-slim
+      dest_image: ghcr.io/toddysm/quarantine/openjdk
+      dest_tag: 27-ea-slim
+      force: ${{ github.event_name == 'workflow_dispatch' && inputs.force || false }}


### PR DESCRIPTION
Adds a scheduled/manual mirror workflow that syncs `openjdk:27-ea-slim` from Docker Hub into `ghcr.io/toddysm/quarantine/openjdk:27-ea-slim`.

Follows the existing mirror pattern (thin caller delegating to `_mirror-image.yml`):
- Daily cron at 06:00 UTC + `workflow_dispatch` with optional `force`.
- `concurrency` group `mirror-quarantine-openjdk`.
- `permissions: contents: read, packages: write`.

Only copies when the source/destination digests differ. New `quarantine/openjdk` package is created on first run (default private).