### PR TITLE
feat(workflows): scan-and-promote workflows (quarantine → golden)

### DIFF
--- a/.github/workflows/_scan-image.yml
+++ b/.github/workflows/_scan-image.yml
@@ -1,0 +1,256 @@
+# Reusable workflow: scan a quarantined repository and promote clean images.
+#
+# This workflow is internal (note the leading underscore in the filename) and is
+# not meant to be triggered directly. It is called by per-image "scan-*"
+# workflows via `uses:`.
+#
+# For every tag in `source_repo` it:
+#   1. scans the image with Trivy,
+#   2. applies a severity threshold plus an optional CVE exception list,
+#   3. promotes passing images into `dest_repo` with `crane copy`,
+#   4. attaches an empty OCI scan-report referrer with `oras attach`, and
+#   5. deletes the promoted tag from quarantine (when a delete token is set).
+#
+# See docs/architecture/workflows/scan-and-promote-workflows.md.
+name: _reusable / scan-image
+
+on:
+  workflow_call:
+    inputs:
+      source_repo:
+        description: "Quarantine repository to scan, without tag (e.g. ghcr.io/toddysm/quarantine/python)."
+        required: true
+        type: string
+      dest_repo:
+        description: "Promotion-target repository, without tag (e.g. ghcr.io/toddysm/golden/python)."
+        required: true
+        type: string
+      severity_threshold:
+        description: "Blocking severity floor: LOW, MEDIUM, HIGH, or CRITICAL."
+        required: false
+        default: HIGH
+        type: string
+      cve_exceptions:
+        description: "Pipe-separated allow-list of CVE IDs (e.g. CVE-2024-1234|CVE-2024-5678)."
+        required: false
+        default: ""
+        type: string
+      delete_source:
+        description: "Delete the tag from quarantine after a successful promotion."
+        required: false
+        default: true
+        type: boolean
+      trivy_version:
+        description: "Trivy version to install (e.g. v0.58.1); also recorded in the referrer."
+        required: false
+        default: v0.58.1
+        type: string
+      dry_run:
+        description: "Scan and report only; never copy, attach, or delete."
+        required: false
+        default: false
+        type: boolean
+    secrets:
+      ghcr_delete_token:
+        description: "PAT with delete:packages used to remove quarantine tags. Optional; deletion is skipped when absent."
+        required: false
+
+jobs:
+  scan:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Set up crane
+        uses: imjasonh/setup-crane@31b88efe9de28ae0ffa220711af4b60be9435f6e # v0.4
+
+      - name: Set up oras
+        uses: oras-project/setup-oras@22ce207df3b08e061f537244349aac6ae1d214f6 # v1.2.4
+        with:
+          version: 1.2.0
+
+      - name: Set up Trivy
+        uses: aquasecurity/setup-trivy@3fb12ec12f41e471780db15c232d5dd185dcb514 # v0.2.6
+        with:
+          version: ${{ inputs.trivy_version }}
+
+      - name: Log in to GHCR
+        run: |
+          set -euo pipefail
+          echo "${{ github.token }}" | crane auth login ghcr.io \
+            --username "${{ github.actor }}" --password-stdin
+          echo "${{ github.token }}" | oras login ghcr.io \
+            --username "${{ github.actor }}" --password-stdin
+
+      - name: Scan, gate, promote, attest, and clean up
+        env:
+          SOURCE_REPO: "${{ inputs.source_repo }}"
+          DEST_REPO: "${{ inputs.dest_repo }}"
+          THRESHOLD: "${{ inputs.severity_threshold }}"
+          EXCEPTIONS: "${{ inputs.cve_exceptions }}"
+          DELETE_SOURCE: "${{ inputs.delete_source }}"
+          DRY_RUN: "${{ inputs.dry_run }}"
+          TRIVY_VERSION: "${{ inputs.trivy_version }}"
+          DELETE_TOKEN: "${{ secrets.ghcr_delete_token }}"
+          # Authenticate Trivy's remote image pulls to GHCR.
+          TRIVY_USERNAME: "${{ github.actor }}"
+          TRIVY_PASSWORD: "${{ github.token }}"
+        run: |
+          set -euo pipefail
+          export LC_ALL=C
+
+          work="$(mktemp -d)"
+
+          # --- Resolve the blocking severity set from the threshold floor. ------
+          case "${THRESHOLD}" in
+            LOW)      SEVERITIES="LOW,MEDIUM,HIGH,CRITICAL" ;;
+            MEDIUM)   SEVERITIES="MEDIUM,HIGH,CRITICAL" ;;
+            HIGH)     SEVERITIES="HIGH,CRITICAL" ;;
+            CRITICAL) SEVERITIES="CRITICAL" ;;
+            *) echo "::error::Invalid severity_threshold '${THRESHOLD}' (expected LOW|MEDIUM|HIGH|CRITICAL)"; exit 1 ;;
+          esac
+
+          # --- Normalise the exception list into a sorted, deduped file. --------
+          exceptions_file="${work}/exceptions.txt"
+          : > "${exceptions_file}"
+          if [ -n "${EXCEPTIONS}" ]; then
+            printf '%s\n' "${EXCEPTIONS}" | tr '|' '\n' | sed '/^[[:space:]]*$/d' \
+              | tr -d '[:space:]' | sort -u > "${exceptions_file}"
+          fi
+
+          # --- Resolve the actual Trivy version for the referrer annotation. ----
+          trivy_resolved="$(trivy version -f json 2>/dev/null | jq -r '.Version // empty' || true)"
+          [ -n "${trivy_resolved}" ] || trivy_resolved="${TRIVY_VERSION#v}"
+
+          # --- Work out the GHCR package coordinates for deletion. --------------
+          owner="$(printf '%s' "${SOURCE_REPO}" | awk -F/ '{print $2}')"
+          pkg_path="$(printf '%s' "${SOURCE_REPO}" | cut -d/ -f3-)"
+          pkg_enc="$(printf '%s' "${pkg_path}" | sed 's:/:%2F:g')"
+          owner_type=""
+          if [ "${DELETE_SOURCE}" = "true" ] && [ -n "${DELETE_TOKEN}" ]; then
+            owner_type="$(GH_TOKEN="${DELETE_TOKEN}" gh api "users/${owner}" --jq '.type' 2>/dev/null || true)"
+          fi
+
+          delete_quarantine_tag() {
+            local tag="$1" base vid
+            if [ "${owner_type}" = "Organization" ]; then
+              base="orgs/${owner}/packages/container/${pkg_enc}"
+            else
+              base="user/packages/container/${pkg_enc}"
+            fi
+            vid="$(GH_TOKEN="${DELETE_TOKEN}" gh api --paginate "${base}/versions" \
+                   --jq ".[] | select(.metadata.container.tags[]? == \"${tag}\") | .id" 2>/dev/null \
+                   | head -n1 || true)"
+            if [ -z "${vid}" ]; then
+              echo "::warning::Could not resolve a package version id for tag '${tag}'; skipping deletion."
+              return 1
+            fi
+            GH_TOKEN="${DELETE_TOKEN}" gh api -X DELETE "${base}/versions/${vid}" >/dev/null
+          }
+
+          # --- Enumerate the quarantine tags. ----------------------------------
+          if ! tags="$(crane ls "${SOURCE_REPO}" 2>/dev/null)"; then
+            tags=""
+          fi
+          if [ -z "${tags}" ]; then
+            echo "No tags found in ${SOURCE_REPO}; nothing to scan."
+            {
+              echo "### Scan & promote: \`${SOURCE_REPO}\` → \`${DEST_REPO}\`"
+              echo ""
+              echo "No tags found in the source repository; nothing to do."
+            } >> "${GITHUB_STEP_SUMMARY}"
+            exit 0
+          fi
+
+          promoted=0
+          blocked=0
+          rows="${work}/rows.md"
+          : > "${rows}"
+
+          while IFS= read -r tag; do
+            [ -n "${tag}" ] || continue
+            src="${SOURCE_REPO}:${tag}"
+            dest="${DEST_REPO}:${tag}"
+            safe="${tag//[^A-Za-z0-9_.-]/_}"
+
+            echo "::group::Scanning ${src}"
+            report="${work}/report-${safe}.json"
+            trivy image --quiet --scanners vuln --severity "${SEVERITIES}" \
+              --format json --output "${report}" "${src}"
+
+            blocking_file="${work}/blocking-${safe}.txt"
+            remaining_file="${work}/remaining-${safe}.txt"
+            excepted_file="${work}/excepted-${safe}.txt"
+            jq -r '[.Results[]?.Vulnerabilities[]?.VulnerabilityID] | unique | .[]' \
+              "${report}" | sort -u > "${blocking_file}"
+            comm -23 "${blocking_file}" "${exceptions_file}" > "${remaining_file}"
+            comm -12 "${blocking_file}" "${exceptions_file}" > "${excepted_file}"
+
+            blocking_count="$(wc -l < "${blocking_file}" | tr -d ' ')"
+            remaining_count="$(wc -l < "${remaining_file}" | tr -d ' ')"
+            excepted_str="$(paste -sd '|' "${excepted_file}")"
+            remaining_str="$(paste -sd ', ' "${remaining_file}")"
+            echo "::endgroup::"
+
+            if [ "${remaining_count}" -gt 0 ]; then
+              blocked=$((blocked + 1))
+              echo "BLOCKED ${src}: ${remaining_str}"
+              printf '| `%s` | :no_entry: blocked | %s | %s | %s |\n' \
+                "${tag}" "${blocking_count}" "${remaining_str}" "${excepted_str:-—}" >> "${rows}"
+              continue
+            fi
+
+            if [ "${DRY_RUN}" = "true" ]; then
+              promoted=$((promoted + 1))
+              echo "DRY-RUN PASS ${src} (would promote to ${dest})"
+              printf '| `%s` | :mag: would promote | %s | — | %s |\n' \
+                "${tag}" "${blocking_count}" "${excepted_str:-—}" >> "${rows}"
+              continue
+            fi
+
+            echo "Promoting ${src} → ${dest}"
+            crane copy "${src}" "${dest}"
+
+            created="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+            oras attach --artifact-type application/vnd.cssc.scan-report.v1+json \
+              --annotation "org.opencontainers.image.created=${created}" \
+              --annotation "com.cssc.scan.source=${SOURCE_REPO}" \
+              --annotation "com.cssc.scan.tag=${tag}" \
+              --annotation "com.cssc.scan.threshold=${THRESHOLD}" \
+              --annotation "com.cssc.scan.exceptions=${excepted_str}" \
+              --annotation "com.cssc.scan.scanner=trivy" \
+              --annotation "com.cssc.scan.scanner-version=${trivy_resolved}" \
+              "${dest}"
+
+            del_status="kept"
+            if [ "${DELETE_SOURCE}" = "true" ]; then
+              if [ -z "${DELETE_TOKEN}" ]; then
+                echo "::warning::delete_source=true but no ghcr_delete_token provided; skipping deletion of ${src}."
+                del_status="skipped (no token)"
+              elif delete_quarantine_tag "${tag}"; then
+                del_status="deleted"
+              else
+                del_status="delete failed"
+              fi
+            fi
+
+            promoted=$((promoted + 1))
+            printf '| `%s` | :white_check_mark: promoted (%s) | %s | — | %s |\n' \
+              "${tag}" "${del_status}" "${blocking_count}" "${excepted_str:-—}" >> "${rows}"
+          done <<EOF
+          ${tags}
+          EOF
+
+          {
+            echo "### Scan & promote: \`${SOURCE_REPO}\` → \`${DEST_REPO}\`"
+            echo ""
+            echo "- **Threshold:** \`${THRESHOLD}\` (severities scanned: \`${SEVERITIES}\`)"
+            echo "- **Scanner:** trivy \`${trivy_resolved}\`"
+            echo "- **Dry run:** \`${DRY_RUN}\`"
+            echo "- **Promoted:** ${promoted} · **Blocked:** ${blocked}"
+            echo ""
+            echo "| Tag | Result | Findings ≥ ${THRESHOLD} | Blocking CVEs | Excepted |"
+            echo "| --- | ------ | --- | --- | --- |"
+            cat "${rows}"
+          } >> "${GITHUB_STEP_SUMMARY}"

--- a/.github/workflows/_scan-image.yml
+++ b/.github/workflows/_scan-image.yml
@@ -68,7 +68,8 @@ jobs:
       - name: Set up oras
         uses: oras-project/setup-oras@22ce207df3b08e061f537244349aac6ae1d214f6 # v1.2.4
         with:
-          version: 1.2.0
+          # ORAS CLI version (independent of the setup-oras action version above).
+          version: 1.3.2
 
       - name: Set up Trivy
         uses: aquasecurity/setup-trivy@3fb12ec12f41e471780db15c232d5dd185dcb514 # v0.2.6
@@ -150,8 +151,21 @@ jobs:
           }
 
           # --- Enumerate the quarantine tags. ----------------------------------
-          if ! tags="$(crane ls "${SOURCE_REPO}" 2>/dev/null)"; then
-            tags=""
+          # Distinguish an empty / not-yet-created repository (expected, exit 0)
+          # from a real failure such as an auth or transient registry error
+          # (must fail loudly rather than silently scanning nothing).
+          ls_err="${work}/crane-ls.err"
+          if tags="$(crane ls "${SOURCE_REPO}" 2>"${ls_err}")"; then
+            :
+          else
+            if grep -qiE 'NAME_UNKNOWN|not found|MANIFEST_UNKNOWN|UNAUTHORIZED.*not found|repository name not known' "${ls_err}"; then
+              echo "Source repository ${SOURCE_REPO} has no tags yet; nothing to scan."
+              tags=""
+            else
+              echo "::error::Failed to list tags for ${SOURCE_REPO}:"
+              cat "${ls_err}" >&2
+              exit 1
+            fi
           fi
           if [ -z "${tags}" ]; then
             echo "No tags found in ${SOURCE_REPO}; nothing to scan."

--- a/.github/workflows/scan-node.yml
+++ b/.github/workflows/scan-node.yml
@@ -1,0 +1,59 @@
+# Scan quarantine/node with Trivy and promote clean images into golden/node.
+#
+# This caller only defines triggers and the repository-specific inputs; the
+# scan/gate/promote/attest/cleanup logic lives in the reusable _scan-image.yml
+# workflow.
+#
+# Naming convention: "scan-<image>.yml" for scan-and-promote workflows, kept
+# separate from "mirror-<image>.yml" and "build-<app>.yml". See
+# docs/contributing/workflow-naming.md.
+name: scan / quarantine/node
+
+on:
+  # Daily scan at 07:00 UTC, after the 06:00 mirror has refreshed quarantine.
+  schedule:
+    - cron: "0 7 * * *"
+  # Manual run with policy overrides.
+  workflow_dispatch:
+    inputs:
+      severity_threshold:
+        description: "Blocking severity floor: LOW, MEDIUM, HIGH, or CRITICAL."
+        required: false
+        default: HIGH
+        type: choice
+        options:
+          - LOW
+          - MEDIUM
+          - HIGH
+          - CRITICAL
+      cve_exceptions:
+        description: "Pipe-separated allow-list of CVE IDs (e.g. CVE-2024-1234|CVE-2024-5678)."
+        required: false
+        default: ""
+        type: string
+      dry_run:
+        description: "Scan and report only; never copy, attach, or delete."
+        required: false
+        default: false
+        type: boolean
+
+# Avoid overlapping runs for this specific scan.
+concurrency:
+  group: scan-quarantine-node
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  scan-node:
+    uses: ./.github/workflows/_scan-image.yml
+    with:
+      source_repo: ghcr.io/toddysm/quarantine/node
+      dest_repo: ghcr.io/toddysm/golden/node
+      severity_threshold: ${{ github.event_name == 'workflow_dispatch' && inputs.severity_threshold || 'HIGH' }}
+      cve_exceptions: ${{ github.event_name == 'workflow_dispatch' && inputs.cve_exceptions || '' }}
+      dry_run: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run || false }}
+    secrets:
+      ghcr_delete_token: ${{ secrets.GHCR_DELETE_TOKEN }}

--- a/.github/workflows/scan-openjdk.yml
+++ b/.github/workflows/scan-openjdk.yml
@@ -1,0 +1,59 @@
+# Scan quarantine/openjdk with Trivy and promote clean images into golden/openjdk.
+#
+# This caller only defines triggers and the repository-specific inputs; the
+# scan/gate/promote/attest/cleanup logic lives in the reusable _scan-image.yml
+# workflow.
+#
+# Naming convention: "scan-<image>.yml" for scan-and-promote workflows, kept
+# separate from "mirror-<image>.yml" and "build-<app>.yml". See
+# docs/contributing/workflow-naming.md.
+name: scan / quarantine/openjdk
+
+on:
+  # Daily scan at 07:00 UTC, after the 06:00 mirror has refreshed quarantine.
+  schedule:
+    - cron: "0 7 * * *"
+  # Manual run with policy overrides.
+  workflow_dispatch:
+    inputs:
+      severity_threshold:
+        description: "Blocking severity floor: LOW, MEDIUM, HIGH, or CRITICAL."
+        required: false
+        default: HIGH
+        type: choice
+        options:
+          - LOW
+          - MEDIUM
+          - HIGH
+          - CRITICAL
+      cve_exceptions:
+        description: "Pipe-separated allow-list of CVE IDs (e.g. CVE-2024-1234|CVE-2024-5678)."
+        required: false
+        default: ""
+        type: string
+      dry_run:
+        description: "Scan and report only; never copy, attach, or delete."
+        required: false
+        default: false
+        type: boolean
+
+# Avoid overlapping runs for this specific scan.
+concurrency:
+  group: scan-quarantine-openjdk
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  scan-openjdk:
+    uses: ./.github/workflows/_scan-image.yml
+    with:
+      source_repo: ghcr.io/toddysm/quarantine/openjdk
+      dest_repo: ghcr.io/toddysm/golden/openjdk
+      severity_threshold: ${{ github.event_name == 'workflow_dispatch' && inputs.severity_threshold || 'HIGH' }}
+      cve_exceptions: ${{ github.event_name == 'workflow_dispatch' && inputs.cve_exceptions || '' }}
+      dry_run: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run || false }}
+    secrets:
+      ghcr_delete_token: ${{ secrets.GHCR_DELETE_TOKEN }}

--- a/.github/workflows/scan-python.yml
+++ b/.github/workflows/scan-python.yml
@@ -1,0 +1,59 @@
+# Scan quarantine/python with Trivy and promote clean images into golden/python.
+#
+# This caller only defines triggers and the repository-specific inputs; the
+# scan/gate/promote/attest/cleanup logic lives in the reusable _scan-image.yml
+# workflow.
+#
+# Naming convention: "scan-<image>.yml" for scan-and-promote workflows, kept
+# separate from "mirror-<image>.yml" and "build-<app>.yml". See
+# docs/contributing/workflow-naming.md.
+name: scan / quarantine/python
+
+on:
+  # Daily scan at 07:00 UTC, after the 06:00 mirror has refreshed quarantine.
+  schedule:
+    - cron: "0 7 * * *"
+  # Manual run with policy overrides.
+  workflow_dispatch:
+    inputs:
+      severity_threshold:
+        description: "Blocking severity floor: LOW, MEDIUM, HIGH, or CRITICAL."
+        required: false
+        default: HIGH
+        type: choice
+        options:
+          - LOW
+          - MEDIUM
+          - HIGH
+          - CRITICAL
+      cve_exceptions:
+        description: "Pipe-separated allow-list of CVE IDs (e.g. CVE-2024-1234|CVE-2024-5678)."
+        required: false
+        default: ""
+        type: string
+      dry_run:
+        description: "Scan and report only; never copy, attach, or delete."
+        required: false
+        default: false
+        type: boolean
+
+# Avoid overlapping runs for this specific scan.
+concurrency:
+  group: scan-quarantine-python
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  scan-python:
+    uses: ./.github/workflows/_scan-image.yml
+    with:
+      source_repo: ghcr.io/toddysm/quarantine/python
+      dest_repo: ghcr.io/toddysm/golden/python
+      severity_threshold: ${{ github.event_name == 'workflow_dispatch' && inputs.severity_threshold || 'HIGH' }}
+      cve_exceptions: ${{ github.event_name == 'workflow_dispatch' && inputs.cve_exceptions || '' }}
+      dry_run: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run || false }}
+    secrets:
+      ghcr_delete_token: ${{ secrets.GHCR_DELETE_TOKEN }}

--- a/docs/architecture/workflows/README.md
+++ b/docs/architecture/workflows/README.md
@@ -8,6 +8,7 @@ Workflows fall into two categories (see
 | Category | Purpose | Status |
 | -------- | ------- | ------ |
 | **Mirror** | Copy / refresh upstream base images from Docker Hub into GHCR | Implemented |
+| **Scan** | Scan quarantined images and promote the ones that pass a vulnerability policy into `golden/<image>` | Planned |
 | **Build** | Build the demo applications under `apps/` on top of mirrored bases | Planned |
 
 ## Documents
@@ -15,3 +16,7 @@ Workflows fall into two categories (see
 - [Image mirror workflows](image-mirror-workflows.md) — how the Docker Hub →
   GHCR mirroring actions are structured, the tooling they use, and what they do
   and deliberately do not do.
+- [Scan-and-promote workflows](scan-and-promote-workflows.md) — how quarantined
+  images are scanned with Trivy, gated on a severity threshold plus CVE
+  exceptions, promoted into `golden/<image>` with a scan-report referrer, and
+  removed from quarantine.

--- a/docs/architecture/workflows/README.md
+++ b/docs/architecture/workflows/README.md
@@ -2,13 +2,13 @@
 
 Architecture documentation for the GitHub Actions workflows in this repository.
 
-Workflows fall into two categories (see
+Workflows fall into three categories (see
 [workflow naming conventions](../../contributing/workflow-naming.md)):
 
 | Category | Purpose | Status |
 | -------- | ------- | ------ |
 | **Mirror** | Copy / refresh upstream base images from Docker Hub into GHCR | Implemented |
-| **Scan** | Scan quarantined images and promote the ones that pass a vulnerability policy into `golden/<image>` | Planned |
+| **Scan** | Scan quarantined images and promote the ones that pass a vulnerability policy into `golden/<image>` | Implemented |
 | **Build** | Build the demo applications under `apps/` on top of mirrored bases | Planned |
 
 ## Documents

--- a/docs/architecture/workflows/scan-and-promote-workflows.md
+++ b/docs/architecture/workflows/scan-and-promote-workflows.md
@@ -1,0 +1,249 @@
+# Scan-and-promote workflows architecture
+
+This document describes the architecture of the GitHub Actions workflows that
+scan the container images sitting in a `quarantine/<image>` repository and
+**promote** the ones that pass a vulnerability policy into a clean
+`golden/<image>` repository. It covers:
+
+1. [How are the actions structured?](#how-are-the-actions-structured)
+2. [What tooling is used?](#what-tooling-is-used)
+3. [What functionality is implemented — and what is not?](#what-functionality-is-implemented-and-what-is-not)
+
+For naming and file-system conventions, see
+[workflow naming conventions](../../contributing/workflow-naming.md). For the
+mirror workflows that populate quarantine in the first place, see
+[image mirror workflows](image-mirror-workflows.md).
+
+## Purpose
+
+The mirror workflows keep a private copy of upstream base images fresh inside
+`quarantine/<image>`. Quarantine is intentionally *untrusted*: an image landing
+there has only been copied, never inspected. The scan-and-promote workflows add
+the missing gate. They:
+
+- enumerate every tag in a `quarantine/<image>` repository,
+- scan each image with [Trivy](https://github.com/aquasecurity/trivy),
+- apply a configurable **severity threshold** plus an optional **CVE exception
+  list**, and
+- for each image that passes, **copy it into `golden/<image>`**, **attach an OCI
+  referrer artifact** that records how/when it was cleared, and **delete the
+  original from quarantine**.
+
+```text
+upstream → [mirror] → quarantine/<image> → [scan + gate] → golden/<image>
+                                                  │
+                                                  └─ blocked images stay in quarantine
+```
+
+The result is that `golden/<image>` only ever contains images that satisfied the
+policy at promotion time, and each one carries a machine-readable scan-report
+referrer describing the decision.
+
+## How are the actions structured
+
+The scan-and-promote workflows follow the same **caller + reusable workflow**
+pattern as the mirror workflows. All shared logic lives in one reusable
+workflow, and each scanned repository gets a thin caller that only supplies
+configuration.
+
+```text
+.github/workflows/
+├── _scan-image.yml      # reusable workflow — all the logic
+└── scan-python.yml      # caller — quarantine/python → golden/python
+```
+
+- **Display name:** `scan / quarantine/<image>` (e.g. `scan / quarantine/python`).
+- **Concurrency group:** `scan-quarantine-<image>` (e.g. `scan-quarantine-python`).
+
+This is the third workflow category, alongside `mirror` and `build`. See the
+[naming conventions](../../contributing/workflow-naming.md).
+
+### Reusable workflow (`_scan-image.yml`)
+
+`_scan-image.yml` is an internal workflow (the leading underscore marks it as
+"do not run directly"). It is triggered only through `workflow_call` and exposes
+the following inputs:
+
+| Input | Required | Default | Description |
+| ----- | -------- | ------- | ----------- |
+| `source_repo` | yes | — | Quarantine repository to scan, without tag (e.g. `ghcr.io/toddysm/quarantine/python`). |
+| `dest_repo` | yes | — | Promotion-target repository, without tag (e.g. `ghcr.io/toddysm/golden/python`). |
+| `severity_threshold` | no | `HIGH` | Blocking severity floor: `LOW`, `MEDIUM`, `HIGH`, or `CRITICAL`. Findings at or above this severity block promotion unless excepted. |
+| `cve_exceptions` | no | `""` | Pipe-separated allow-list of CVE IDs (e.g. `CVE-2024-1234\|CVE-2024-5678`). |
+| `delete_source` | no | `true` | Delete the tag from quarantine after a successful promotion. |
+| `trivy_version` | no | pinned | Trivy version to install; also recorded in the referrer artifact. |
+| `dry_run` | no | `false` | Scan and report only; never copy, attach, or delete. |
+
+It also accepts one optional secret:
+
+| Secret | Required | Description |
+| ------ | -------- | ----------- |
+| `ghcr_delete_token` | no | PAT with `delete:packages` used to delete quarantine tags via the GitHub Packages REST API. When absent, deletion is skipped with a warning (see [source deletion](#source-deletion)). |
+
+The reusable workflow defines a single `scan` job running on `ubuntu-latest`
+with minimal permissions (`contents: read`, `packages: write`). It performs:
+
+1. **Set up tooling** — installs `crane`, `oras`, and `trivy` (all pinned).
+2. **Log in to GHCR** — authenticates `crane`, `oras`, and Trivy to `ghcr.io`
+   using the built-in `GITHUB_TOKEN` and the triggering actor.
+3. **Enumerate and process tags** — the core scan/gate/promote loop described
+   below.
+4. **Write a job summary** — one row per tag: promoted, blocked, or skipped.
+
+### Caller workflows (`scan-<image>.yml`)
+
+Each caller contains no shell logic. A caller only declares:
+
+- **Triggers** — a daily `schedule` (07:00 UTC, after the 06:00 mirror) and a
+  manual `workflow_dispatch` exposing overrides for `severity_threshold`,
+  `cve_exceptions`, and `dry_run`.
+- **Concurrency** — a per-image group (`scan-quarantine-<image>`) with
+  `cancel-in-progress: false`.
+- **Permissions** — `contents: read`, `packages: write`.
+- **A single job** that calls `./.github/workflows/_scan-image.yml` via `uses:`,
+  passes the image-specific inputs, and forwards the `ghcr_delete_token` secret.
+
+Adding a new scanned repository is a copy-and-edit operation on a caller file
+with no logic changes.
+
+### Control flow
+
+The job lists every tag in `source_repo` and processes each one independently:
+
+```mermaid
+flowchart TD
+    A[schedule 07:00 UTC] --> C[caller scan-image.yml]
+    B[workflow_dispatch + overrides] --> C
+    C -->|uses: with inputs| D[_scan-image.yml]
+    D --> E[setup crane + oras + trivy]
+    E --> F[login ghcr.io]
+    F --> G[crane ls source_repo]
+    G --> H[for each tag]
+    H --> I[trivy image --format json --severity threshold..CRITICAL]
+    I --> J[blocking = findings at/above threshold]
+    J --> K[excepted_found = blocking ∩ cve_exceptions]
+    K --> L[remaining = blocking − cve_exceptions]
+    L --> M{remaining empty?}
+    M -->|no| N[BLOCKED: stays in quarantine, report CVEs]
+    M -->|yes| O[crane copy source:tag → dest:tag]
+    O --> P[oras attach scan-report referrer to dest:tag]
+    P --> Q{delete_source and token present?}
+    Q -->|yes| R[delete source:tag via Packages REST API]
+    Q -->|no| S[keep source:tag, warn]
+    N --> T[job summary]
+    R --> T
+    S --> T
+```
+
+### Gate semantics
+
+For each tag the gate is evaluated as follows:
+
+- **Severity floor.** `severity_threshold` is expanded to the set of severities
+  at or above it — for example `HIGH` → `HIGH,CRITICAL` — which is passed to
+  Trivy's `--severity` flag. Findings below the floor are ignored entirely.
+- **Blocking findings.** The CVE IDs Trivy reports at or above the floor.
+- **Exceptions.** Any blocking CVE listed in `cve_exceptions` is removed from the
+  blocking set and instead recorded in the referrer's `exceptions` annotation.
+- **Decision.** If the blocking set is empty after removing exceptions, the image
+  is promoted. Otherwise it is left in quarantine and the run reports the
+  offending CVEs. Blocked images never fail the whole job; the run finishes and
+  the summary lists every outcome.
+
+## What tooling is used
+
+| Tool | Role |
+| ---- | ---- |
+| **GitHub Actions** | Orchestration: scheduling, manual dispatch, reusable-workflow composition, concurrency, and job summaries. |
+| **[Trivy](https://github.com/aquasecurity/trivy)** | Vulnerability scanner. Scans each remote image and emits JSON filtered to the configured severity floor. |
+| **[`crane`](https://github.com/google/go-containerregistry/blob/main/cmd/crane/README.md)** | Registry client: `crane ls` to enumerate tags and `crane copy` to promote images (preserving multi-architecture manifest lists). |
+| **[`oras`](https://oras.land)** | Creates and attaches the empty scan-report referrer (`oras attach` with annotations only). |
+| **`jq`** | Parses Trivy JSON and computes the blocking, excepted, and remaining CVE sets. |
+| **`GITHUB_TOKEN`** | Built-in token used to authenticate to GHCR for scan, copy, and attach (`packages: write`). |
+| **Optional `ghcr_delete_token` PAT** | Used only for deleting quarantine tags via the GitHub Packages REST API. |
+| **`ubuntu-latest` runner** | GitHub-hosted runner the job executes on. |
+
+Key characteristics:
+
+- **`crane copy` preserves multi-architecture manifest lists**, so promoted
+  images keep all their original platforms.
+- **Pinned tooling.** Third-party setup actions and tool versions are pinned for
+  supply-chain safety; the pinned Trivy version is recorded in each referrer.
+
+## Scan-report referrer artifact
+
+For every promoted image the workflow attaches an **OCI referrer artifact** to
+the image in `golden/<image>`. It is an *empty* artifact — a manifest with the
+standard empty config descriptor and **no layer blobs** — created with
+`oras attach` using annotations only. Its `subject` is the promoted image, so
+registry clients (`oras discover`, `crane manifest`, etc.) can list it as a
+referrer of the image.
+
+- **Artifact type:** `application/vnd.cssc.scan-report.v1+json`
+
+| Annotation key | Example value | Meaning |
+| -------------- | ------------- | ------- |
+| `org.opencontainers.image.created` | `2026-06-05T07:03:11Z` | Date/time of the scan (RFC 3339, UTC). |
+| `com.cssc.scan.source` | `ghcr.io/toddysm/quarantine/python` | Original registry + repository the image came from. |
+| `com.cssc.scan.tag` | `3.14-slim` | Image tag that was scanned and promoted. |
+| `com.cssc.scan.threshold` | `HIGH` | Severity threshold the image passed. |
+| `com.cssc.scan.exceptions` | `CVE-2024-1234\|CVE-2024-5678` | Pipe-separated CVEs found in the image at/above the threshold but cleared via the exception list (empty if none). |
+| `com.cssc.scan.scanner` | `trivy` | Scanner name. |
+| `com.cssc.scan.scanner-version` | `0.52.0` | Scanner version. |
+
+## What functionality is implemented and what is not
+
+### Implemented
+
+- **Policy-gated promotion.** Images are copied into `golden/<image>` only when
+  they pass the configurable severity threshold after applying the CVE exception
+  list.
+- **Per-repository tag enumeration.** Every tag in the quarantine repository is
+  scanned and gated independently in one run.
+- **Multi-architecture preservation** via `crane copy`.
+- **Scan-report provenance.** Each promoted image gets an empty OCI referrer
+  artifact recording scan date, source, tag, threshold, excepted CVEs, and
+  scanner name/version.
+- **Quarantine cleanup.** Promoted tags are deleted from quarantine when a
+  delete token is configured (see below).
+- **Scheduled and manual runs.** A daily cron plus `workflow_dispatch` with
+  overrides for threshold, exceptions, and a no-op `dry_run` mode.
+- **Concurrency safety.** Per-image concurrency groups prevent overlapping runs.
+- **DRY, single-source-of-truth logic.** All behavior lives in one reusable
+  workflow; per-image callers are configuration only.
+
+### Source deletion
+
+The built-in `GITHUB_TOKEN` with `packages: write` can push and pull but
+**cannot delete** GHCR package versions. Reliable deletion uses the GitHub
+Packages REST API
+(`DELETE /user/packages/container/<name>/versions/<version_id>`), which requires
+a PAT carrying `delete:packages`.
+
+The workflow therefore treats deletion as configurable:
+
+- `delete_source` defaults to `true`.
+- Deletion uses the optional `ghcr_delete_token` secret.
+- If `delete_source` is `true` but no token is provided, the run **skips
+  deletion and logs a warning** rather than failing. The promotion and referrer
+  steps still succeed.
+
+### Not implemented (deliberately out of scope)
+
+- **No signing or SBOM attestation.** Promoted images are not signed (e.g.
+  cosign) and no SBOM/provenance attestations are produced. The only attached
+  metadata is the scan-report referrer.
+- **No automatic remediation.** Blocked images are left in quarantine; the
+  workflow does not patch, rebuild, or open tickets for them.
+- **No cross-scanner support.** Trivy is the only scanner; the referrer schema
+  records the scanner name/version to allow future additions.
+- **No retention policy for `golden/`.** Superseded golden tags are not pruned.
+- **No notification/alerting.** Failures and blocked images surface only through
+  the normal GitHub Actions run status and the job summary.
+
+## Adding a new scanned repository
+
+1. Copy `scan-python.yml` to `scan-<image>.yml`.
+2. Update the display `name:`, the `concurrency.group`, and the inputs
+   (`source_repo`, `dest_repo`, and any threshold/exception overrides).
+3. No logic changes are needed — the reusable workflow does the work.

--- a/docs/architecture/workflows/scan-and-promote-workflows.md
+++ b/docs/architecture/workflows/scan-and-promote-workflows.md
@@ -49,7 +49,9 @@ configuration.
 ```text
 .github/workflows/
 ├── _scan-image.yml      # reusable workflow — all the logic
-└── scan-python.yml      # caller — quarantine/python → golden/python
+├── scan-python.yml      # caller — quarantine/python  → golden/python
+├── scan-node.yml        # caller — quarantine/node    → golden/node
+└── scan-openjdk.yml     # caller — quarantine/openjdk → golden/openjdk
 ```
 
 - **Display name:** `scan / quarantine/<image>` (e.g. `scan / quarantine/python`).

--- a/docs/contributing/workflow-naming.md
+++ b/docs/contributing/workflow-naming.md
@@ -11,15 +11,16 @@ both in the file system and in the Actions UI.
 | Category | Purpose | Workflow file | Display `name:` | Concurrency group |
 | -------- | ------- | ------------- | --------------- | ----------------- |
 | **Mirror** | Copy / refresh a base image from an upstream registry into GHCR | `mirror-<image>.yml` | `mirror / quarantine/<image>` | `mirror-quarantine-<image>` |
+| **Scan** | Scan a quarantined image and promote it into `golden/<image>` when it passes the vulnerability policy | `scan-<image>.yml` | `scan / quarantine/<image>` | `scan-quarantine-<image>` |
 | **Build** | Build an application image on top of a mirrored base | `build-<app>.yml` | `build / <app>` | `build-<app>` |
 | **Reusable** | Shared logic invoked by other workflows; never triggered directly | `_<purpose>.yml` (leading underscore) | `_reusable / <purpose>` | n/a |
 
 ### Rules
 
 1. **Verb prefix.** Every workflow filename starts with a category verb:
-   `mirror-`, `build-`, or a leading underscore (`_`) for reusable workflows.
-   This groups related workflows together alphabetically and makes intent
-   obvious at a glance.
+   `mirror-`, `scan-`, `build-`, or a leading underscore (`_`) for reusable
+   workflows. This groups related workflows together alphabetically and makes
+   intent obvious at a glance.
 2. **Leading underscore = internal.** Reusable workflows (triggered by
    `workflow_call`) are prefixed with `_` so they sort to the top of the list
    and signal "do not run me directly."
@@ -29,6 +30,8 @@ both in the file system and in the Actions UI.
    job never overlap, while different images/apps run independently.
 5. **GHCR destination repositories** for mirrored base images follow the
    `quarantine/<image>` scheme, e.g. `ghcr.io/<owner>/quarantine/python`.
+   Images promoted out of quarantine by a scan workflow follow the
+   `golden/<image>` scheme, e.g. `ghcr.io/<owner>/golden/python`.
 
 ## Mirror workflows
 
@@ -53,6 +56,37 @@ Mirror workflows keep a copy of an upstream base image fresh in GHCR.
 1. Copy `mirror-python.yml` to `mirror-<image>.yml`.
 2. Update the display `name:`, the `concurrency.group`, and the four inputs
    (`source_image`, `source_tag`, `dest_image`, `dest_tag`).
+3. No logic changes are needed — the reusable workflow does the work.
+
+## Scan workflows
+
+Scan workflows gate images out of quarantine. They scan every tag in a
+`quarantine/<image>` repository with Trivy and promote the images that pass a
+configurable severity threshold (plus an optional CVE exception list) into a
+`golden/<image>` repository.
+
+- **Structure.** Logic lives in a single reusable workflow,
+  [`_scan-image.yml`](../../.github/workflows/_scan-image.yml). Each scanned
+  repository has a thin caller, e.g.
+  [`scan-python.yml`](../../.github/workflows/scan-python.yml), that only
+  declares triggers and the repository-specific inputs and calls the reusable
+  workflow via `uses:`.
+- **Gate + promote.** Passing images are copied with `crane copy`, get an empty
+  OCI scan-report referrer attached with `oras attach`, and are then deleted
+  from quarantine. Blocked images stay in quarantine.
+- **Triggers.** A daily `schedule` (07:00 UTC, after the 06:00 mirror) plus
+  `workflow_dispatch` with overrides for the threshold, exceptions, and a
+  `dry_run` mode.
+- **Auth.** GHCR scan/copy/attach use the built-in `GITHUB_TOKEN`
+  (`packages: write`). Deleting quarantine tags needs a separate
+  `delete:packages` PAT (see the
+  [scan-and-promote architecture](../architecture/workflows/scan-and-promote-workflows.md)).
+
+### Adding a new scan workflow
+
+1. Copy `scan-python.yml` to `scan-<image>.yml`.
+2. Update the display `name:`, the `concurrency.group`, and the inputs
+   (`source_repo`, `dest_repo`, and any threshold/exception overrides).
 3. No logic changes are needed — the reusable workflow does the work.
 
 ## Build workflows


### PR DESCRIPTION
## Summary

Adds a **scan-and-promote** workflow category that gates images out of `quarantine/<image>` into `golden/<image>` using Trivy. Third workflow category alongside `mirror` and `build`, using the same caller + reusable-workflow pattern.

For each tag in `quarantine/<image>`: scan with Trivy → apply severity threshold (default `HIGH`) + CVE exception list → if it passes, `crane copy` to `golden/<image>`, attach an empty OCI scan-report referrer with `oras attach`, then delete the source tag from quarantine.

## Changes

- `.github/workflows/_scan-image.yml` — reusable scan/gate/promote/attest/cleanup workflow
- `.github/workflows/scan-python.yml` — caller for `quarantine/python` → `golden/python`
- `docs/architecture/workflows/scan-and-promote-workflows.md` — architecture doc
- README + naming-conventions updates for the new `scan` category

## Notes

- Setup actions SHA-pinned (`setup-oras` v1.2.4, `setup-trivy` v0.2.6).
- Quarantine deletion uses the optional `GHCR_DELETE_TOKEN` secret; absent → promotion/attest still run, deletion skipped with a warning.
- Blocked images do not fail the run; every tag's outcome is reported in the job summary.

## Closes

Closes #41, closes #42, closes #43, closes #44, closes #45
