### PR TITLE
feat(workflows): detailed per-image scan report

### DIFF
--- a/.github/workflows/_scan-image.yml
+++ b/.github/workflows/_scan-image.yml
@@ -206,8 +206,12 @@ jobs:
             blocking_count="$(wc -l < "${blocking_file}" | tr -d ' ')"
             remaining_count="$(wc -l < "${remaining_file}" | tr -d ' ')"
             excepted_count="$(wc -l < "${excepted_file}" | tr -d ' ')"
+            # Pipe-separated form is used only for the oras annotation.
             excepted_str="$(paste -sd '|' "${excepted_file}")"
-            remaining_str="$(paste -sd ', ' "${remaining_file}")"
+            # Comma-separated, Markdown-safe display forms for the summary tables
+            # (CVE IDs contain no '|', so a comma join keeps table columns intact).
+            remaining_md="$(paste -sd ',' "${remaining_file}" | sed 's/,/, /g')"
+            excepted_md="$(paste -sd ',' "${excepted_file}" | sed 's/,/, /g')"
 
             # Per-CVE detail: id, severity, package, installed, fixed (deduped, ranked).
             vulns_tsv="${work}/vulns-${safe}.tsv"
@@ -276,7 +280,7 @@ jobs:
               echo "Result:           ${result}"
               echo "Promoted:         ${promoted_yesno}"
               echo "Threshold:        ${THRESHOLD} (severities: ${SEVERITIES})"
-              echo "Findings ≥ floor: ${blocking_count} (blocking: ${remaining_count}, excepted: ${excepted_count})"
+              echo "CVEs ≥ ${THRESHOLD}:   ${blocking_count} (blocking: ${remaining_count}, excepted: ${excepted_count})"
               if [ -s "${vulns_tsv}" ]; then
                 printf '  %-22s %-9s %-28s %-18s %s\n' "CVE" "SEVERITY" "PACKAGE" "INSTALLED" "STATUS"
                 while IFS="$(printf '\t')" read -r id sev pkg installed fixed; do
@@ -286,17 +290,17 @@ jobs:
               else
                 echo "  (no vulnerabilities at or above the threshold)"
               fi
-            } | tee -a "${work}/console-report.txt"
+            }
 
             # --- Summary table row. ----------------------------------------------
             printf '| `%s` | %s %s | %s | %s | %s |\n' \
               "${tag}" "${icon}" "${result}" "${blocking_count}" \
-              "${remaining_str:-—}" "${excepted_str:-—}" >> "${rows}"
+              "${remaining_md:-—}" "${excepted_md:-—}" >> "${rows}"
 
             # --- Collapsible per-image detail for the job summary. ----------------
             {
               echo ""
-              echo "<details><summary><code>${tag}</code> — ${icon} ${result} · ${blocking_count} finding(s) ≥ ${THRESHOLD}</summary>"
+              echo "<details><summary><code>${tag}</code> — ${icon} ${result} · ${blocking_count} CVE(s) ≥ ${THRESHOLD}</summary>"
               echo ""
               echo "- **Source:** \`${src}\`"
               echo "- **Destination:** \`${dest}\`"
@@ -333,7 +337,7 @@ jobs:
             echo "- **Dry run:** \`${DRY_RUN}\`"
             echo "- **Promoted:** ${promoted} · **Blocked:** ${blocked}"
             echo ""
-            echo "| Tag | Result | Findings ≥ ${THRESHOLD} | Blocking CVEs | Excepted |"
+            echo "| Tag | Result | CVEs ≥ ${THRESHOLD} | Blocking CVEs | Excepted |"
             echo "| --- | ------ | --- | --- | --- |"
             cat "${rows}"
             echo ""

--- a/.github/workflows/_scan-image.yml
+++ b/.github/workflows/_scan-image.yml
@@ -180,7 +180,9 @@ jobs:
           promoted=0
           blocked=0
           rows="${work}/rows.md"
+          details_md="${work}/details.md"
           : > "${rows}"
+          : > "${details_md}"
 
           while IFS= read -r tag; do
             [ -n "${tag}" ] || continue
@@ -203,55 +205,122 @@ jobs:
 
             blocking_count="$(wc -l < "${blocking_file}" | tr -d ' ')"
             remaining_count="$(wc -l < "${remaining_file}" | tr -d ' ')"
+            excepted_count="$(wc -l < "${excepted_file}" | tr -d ' ')"
             excepted_str="$(paste -sd '|' "${excepted_file}")"
             remaining_str="$(paste -sd ', ' "${remaining_file}")"
+
+            # Per-CVE detail: id, severity, package, installed, fixed (deduped, ranked).
+            vulns_tsv="${work}/vulns-${safe}.tsv"
+            jq -r '
+              [ .Results[]? | (.Vulnerabilities[]? | {
+                  id: .VulnerabilityID,
+                  sev: (.Severity // "UNKNOWN"),
+                  pkg: (.PkgName // ""),
+                  installed: (.InstalledVersion // ""),
+                  fixed: (.FixedVersion // "")
+                }) ]
+              | unique_by("\(.id)|\(.pkg)|\(.installed)")
+              | map(. + {rank: ({"CRITICAL":0,"HIGH":1,"MEDIUM":2,"LOW":3}[.sev] // 9)})
+              | sort_by(.rank, .id)
+              | .[] | [.id, .sev, .pkg, .installed, .fixed] | @tsv
+            ' "${report}" > "${vulns_tsv}"
             echo "::endgroup::"
 
+            # --- Decide the outcome for this tag. --------------------------------
             if [ "${remaining_count}" -gt 0 ]; then
               blocked=$((blocked + 1))
-              echo "BLOCKED ${src}: ${remaining_str}"
-              printf '| `%s` | :no_entry: blocked | %s | %s | %s |\n' \
-                "${tag}" "${blocking_count}" "${remaining_str}" "${excepted_str:-—}" >> "${rows}"
-              continue
-            fi
-
-            if [ "${DRY_RUN}" = "true" ]; then
+              result="blocked"
+              icon=":no_entry:"
+              promoted_yesno="no (left in quarantine)"
+            elif [ "${DRY_RUN}" = "true" ]; then
               promoted=$((promoted + 1))
-              echo "DRY-RUN PASS ${src} (would promote to ${dest})"
-              printf '| `%s` | :mag: would promote | %s | — | %s |\n' \
-                "${tag}" "${blocking_count}" "${excepted_str:-—}" >> "${rows}"
-              continue
-            fi
+              result="would promote"
+              icon=":mag:"
+              promoted_yesno="no (dry run)"
+            else
+              crane copy "${src}" "${dest}"
 
-            echo "Promoting ${src} → ${dest}"
-            crane copy "${src}" "${dest}"
+              created="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+              oras attach --artifact-type application/vnd.cssc.scan-report.v1+json \
+                --annotation "org.opencontainers.image.created=${created}" \
+                --annotation "com.cssc.scan.source=${SOURCE_REPO}" \
+                --annotation "com.cssc.scan.tag=${tag}" \
+                --annotation "com.cssc.scan.threshold=${THRESHOLD}" \
+                --annotation "com.cssc.scan.exceptions=${excepted_str}" \
+                --annotation "com.cssc.scan.scanner=trivy" \
+                --annotation "com.cssc.scan.scanner-version=${trivy_resolved}" \
+                "${dest}"
 
-            created="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
-            oras attach --artifact-type application/vnd.cssc.scan-report.v1+json \
-              --annotation "org.opencontainers.image.created=${created}" \
-              --annotation "com.cssc.scan.source=${SOURCE_REPO}" \
-              --annotation "com.cssc.scan.tag=${tag}" \
-              --annotation "com.cssc.scan.threshold=${THRESHOLD}" \
-              --annotation "com.cssc.scan.exceptions=${excepted_str}" \
-              --annotation "com.cssc.scan.scanner=trivy" \
-              --annotation "com.cssc.scan.scanner-version=${trivy_resolved}" \
-              "${dest}"
-
-            del_status="kept"
-            if [ "${DELETE_SOURCE}" = "true" ]; then
-              if [ -z "${DELETE_TOKEN}" ]; then
-                echo "::warning::delete_source=true but no ghcr_delete_token provided; skipping deletion of ${src}."
-                del_status="skipped (no token)"
-              elif delete_quarantine_tag "${tag}"; then
-                del_status="deleted"
-              else
-                del_status="delete failed"
+              del_status="kept"
+              if [ "${DELETE_SOURCE}" = "true" ]; then
+                if [ -z "${DELETE_TOKEN}" ]; then
+                  echo "::warning::delete_source=true but no ghcr_delete_token provided; skipping deletion of ${src}."
+                  del_status="skipped (no token)"
+                elif delete_quarantine_tag "${tag}"; then
+                  del_status="deleted"
+                else
+                  del_status="delete failed"
+                fi
               fi
+
+              promoted=$((promoted + 1))
+              result="promoted (source ${del_status})"
+              icon=":white_check_mark:"
+              promoted_yesno="yes → ${dest}"
             fi
 
-            promoted=$((promoted + 1))
-            printf '| `%s` | :white_check_mark: promoted (%s) | %s | — | %s |\n' \
-              "${tag}" "${del_status}" "${blocking_count}" "${excepted_str:-—}" >> "${rows}"
+            # --- Human-readable report to the run log. ---------------------------
+            {
+              echo "================================================================"
+              echo "Image:            ${src}"
+              echo "Result:           ${result}"
+              echo "Promoted:         ${promoted_yesno}"
+              echo "Threshold:        ${THRESHOLD} (severities: ${SEVERITIES})"
+              echo "Findings ≥ floor: ${blocking_count} (blocking: ${remaining_count}, excepted: ${excepted_count})"
+              if [ -s "${vulns_tsv}" ]; then
+                printf '  %-22s %-9s %-28s %-18s %s\n' "CVE" "SEVERITY" "PACKAGE" "INSTALLED" "STATUS"
+                while IFS="$(printf '\t')" read -r id sev pkg installed fixed; do
+                  if grep -qxF "${id}" "${exceptions_file}"; then st="EXCEPTED"; else st="BLOCKING"; fi
+                  printf '  %-22s %-9s %-28s %-18s %s\n' "${id}" "${sev}" "${pkg}" "${installed:-—}" "${st}"
+                done < "${vulns_tsv}"
+              else
+                echo "  (no vulnerabilities at or above the threshold)"
+              fi
+            } | tee -a "${work}/console-report.txt"
+
+            # --- Summary table row. ----------------------------------------------
+            printf '| `%s` | %s %s | %s | %s | %s |\n' \
+              "${tag}" "${icon}" "${result}" "${blocking_count}" \
+              "${remaining_str:-—}" "${excepted_str:-—}" >> "${rows}"
+
+            # --- Collapsible per-image detail for the job summary. ----------------
+            {
+              echo ""
+              echo "<details><summary><code>${tag}</code> — ${icon} ${result} · ${blocking_count} finding(s) ≥ ${THRESHOLD}</summary>"
+              echo ""
+              echo "- **Source:** \`${src}\`"
+              echo "- **Destination:** \`${dest}\`"
+              echo "- **Promoted:** ${promoted_yesno}"
+              echo "- **Blocking (not excepted):** ${remaining_count} · **Excepted:** ${excepted_count}"
+              echo ""
+              echo "| CVE | Severity | Package | Installed | Fixed | Status |"
+              echo "| --- | --- | --- | --- | --- | --- |"
+              if [ -s "${vulns_tsv}" ]; then
+                while IFS="$(printf '\t')" read -r id sev pkg installed fixed; do
+                  if grep -qxF "${id}" "${exceptions_file}"; then
+                    st=":large_yellow_circle: excepted"
+                  else
+                    st=":red_circle: blocking"
+                  fi
+                  printf '| %s | %s | `%s` | %s | %s | %s |\n' \
+                    "${id}" "${sev}" "${pkg}" "${installed:-—}" "${fixed:-—}" "${st}"
+                done < "${vulns_tsv}"
+              else
+                echo "| — | — | — | — | — | none ≥ ${THRESHOLD} |"
+              fi
+              echo ""
+              echo "</details>"
+            } >> "${details_md}"
           done <<EOF
           ${tags}
           EOF
@@ -267,4 +336,9 @@ jobs:
             echo "| Tag | Result | Findings ≥ ${THRESHOLD} | Blocking CVEs | Excepted |"
             echo "| --- | ------ | --- | --- | --- |"
             cat "${rows}"
+            echo ""
+            echo "#### Per-image vulnerability detail"
+            echo ""
+            echo "Status legend: :red_circle: blocking (counts against the threshold) · :large_yellow_circle: excepted (matched the exception list)."
+            cat "${details_md}"
           } >> "${GITHUB_STEP_SUMMARY}"

--- a/docs/architecture/workflows/scan-and-promote-workflows.md
+++ b/docs/architecture/workflows/scan-and-promote-workflows.md
@@ -90,7 +90,11 @@ with minimal permissions (`contents: read`, `packages: write`). It performs:
    using the built-in `GITHUB_TOKEN` and the triggering actor.
 3. **Enumerate and process tags** — the core scan/gate/promote loop described
    below.
-4. **Write a job summary** — one row per tag: promoted, blocked, or skipped.
+4. **Write a report** — a human-readable per-image report to the run log and a
+   job summary that combines a one-row-per-tag overview table with a collapsible
+   per-image vulnerability detail (every CVE found at or above the threshold,
+   its severity, package, installed/fixed versions, and whether it was blocking
+   or excepted).
 
 ### Caller workflows (`scan-<image>.yml`)
 
@@ -208,6 +212,10 @@ referrer of the image.
   scanner name/version.
 - **Quarantine cleanup.** Promoted tags are deleted from quarantine when a
   delete token is configured (see below).
+- **Detailed scan reporting.** For every scanned tag the workflow prints a
+  report to the run log and to the job summary: whether the image was promoted
+  or left in quarantine, and a per-CVE breakdown (severity, package,
+  installed/fixed versions) marking each finding as blocking or excepted.
 - **Scheduled and manual runs.** A daily cron plus `workflow_dispatch` with
   overrides for threshold, exceptions, and a no-op `dry_run` mode.
 - **Concurrency safety.** Per-image concurrency groups prevent overlapping runs.


### PR DESCRIPTION
## Summary

Adds detailed scan reporting to the reusable `_scan-image.yml` workflow. For every scanned tag the workflow now produces a clear report of what was scanned, whether it was promoted, and the vulnerabilities found — including whether each one was blocking or covered by the exception list.

## What's new

- **Run-log report** per image: image ref, outcome (promoted / left in quarantine / dry-run), threshold, finding counts, and a per-CVE table (CVE, severity, package, installed version, blocking-vs-excepted).
- **Job summary** keeps the per-tag overview table and adds a collapsible **per-image vulnerability detail** section listing each CVE with severity, package, installed/fixed versions, and a blocking/excepted status (with a legend).
- CVEs are deduplicated and ordered by severity (CRITICAL → LOW).

## Validation

- YAML parse, `bash -n`, and `actionlint` all pass.
- Smoke-tested the parsing/report logic against a mock Trivy JSON: dedup, severity ranking, and exception matching verified.

## Notes

No input or behavior changes to the gate itself — this is reporting only. Docs updated in `scan-and-promote-workflows.md`.
