### PR TITLE
fix(workflows): pin ORAS CLI to 1.3.0 supported by setup-oras

### DIFF
--- a/.github/workflows/_scan-image.yml
+++ b/.github/workflows/_scan-image.yml
@@ -69,7 +69,9 @@ jobs:
         uses: oras-project/setup-oras@22ce207df3b08e061f537244349aac6ae1d214f6 # v1.2.4
         with:
           # ORAS CLI version (independent of the setup-oras action version above).
-          version: 1.3.2
+          # Must be a version known to the pinned setup-oras action; v1.2.4
+          # supports ORAS CLI up to 1.3.0.
+          version: 1.3.0
 
       - name: Set up Trivy
         uses: aquasecurity/setup-trivy@3fb12ec12f41e471780db15c232d5dd185dcb514 # v0.2.6


### PR DESCRIPTION
## Problem

`scan-python` (and the other scan callers) fail at the **Set up oras** step:

```
official ORAS CLI releases does not contain version 1.3.2
Error: official ORAS CLI releases does not contain version 1.3.2
```

## Cause

`oras-project/setup-oras@v1.2.4` validates the requested ORAS CLI version against a baked-in release list. That list only goes up to **1.3.0** (even setup-oras v2.0.0 only knows 1.3.1), so requesting `1.3.2` is rejected.

## Fix

Pin the ORAS CLI to `1.3.0` — the highest version known to the pinned `setup-oras@v1.2.4` — and add a comment documenting the constraint so future bumps stay within the action's supported set.

Validated with YAML parse and actionlint.
