### PR TITLE
fix(workflows): bump Trivy to v0.71.0 and setup-oras to v2.0.0 (Node 24)

### DIFF
--- a/.github/workflows/_scan-image.yml
+++ b/.github/workflows/_scan-image.yml
@@ -41,9 +41,9 @@ on:
         default: true
         type: boolean
       trivy_version:
-        description: "Trivy version to install (e.g. v0.58.1); also recorded in the referrer."
+        description: "Trivy version to install (e.g. v0.71.0); also recorded in the referrer."
         required: false
-        default: v0.58.1
+        default: v0.71.0
         type: string
       dry_run:
         description: "Scan and report only; never copy, attach, or delete."
@@ -66,12 +66,12 @@ jobs:
         uses: imjasonh/setup-crane@31b88efe9de28ae0ffa220711af4b60be9435f6e # v0.4
 
       - name: Set up oras
-        uses: oras-project/setup-oras@22ce207df3b08e061f537244349aac6ae1d214f6 # v1.2.4
+        uses: oras-project/setup-oras@38de303aac69abb66f3e6255b7198bff35f323e3 # v2.0.0
         with:
           # ORAS CLI version (independent of the setup-oras action version above).
-          # Must be a version known to the pinned setup-oras action; v1.2.4
-          # supports ORAS CLI up to 1.3.0.
-          version: 1.3.0
+          # Must be a version known to the pinned setup-oras action; v2.0.0
+          # supports ORAS CLI up to 1.3.1.
+          version: 1.3.1
 
       - name: Set up Trivy
         uses: aquasecurity/setup-trivy@3fb12ec12f41e471780db15c232d5dd185dcb514 # v0.2.6


### PR DESCRIPTION
Fixes two issues observed when running the `scan-*` workflows.

## 1. Trivy install failure

```
installing Trivy binary
aquasecurity/trivy info checking GitHub for tag 'v0.58.1'
aquasecurity/trivy info found version: 0.58.1 for v0.58.1/Linux/64bit
Error: Process completed with exit code 1.
```

**Cause:** the old default `trivy_version: v0.58.1` no longer installs through the current Trivy `install.sh` — it fails right after resolving the version. Reproduced locally: `v0.58.1` exits 1, `v0.71.0` installs cleanly (exit 0).

**Fix:** bump the default `trivy_version` to `v0.71.0` (current latest). The version is still overridable per-call and recorded in the scan-report referrer.

## 2. setup-oras Node 20 deprecation warning

```
Node.js 20 actions are deprecated ... oras-project/setup-oras@22ce207...
```

**Fix:** upgrade `setup-oras` from v1.2.4 (Node 20) to **v2.0.0** (Node 24, SHA-pinned `38de303…`). v2.0.0 supports the ORAS CLI up to 1.3.1, so the pinned CLI is bumped `1.3.0 → 1.3.1`.

(`setup-crane` is a composite action and `setup-trivy` is composite too, so neither triggers the Node 20 deprecation.)

Validated with YAML parse and actionlint.
