### PR TITLE
Add mirror & scan workflows for hardened python DHI

### DIFF
--- a/.github/workflows/_mirror-image.yml
+++ b/.github/workflows/_mirror-image.yml
@@ -33,6 +33,18 @@ on:
         required: false
         default: false
         type: boolean
+      source_login_registry:
+        description: "Registry to authenticate to before pulling the source (e.g. dhi.io). Leave empty for anonymous public pulls."
+        required: false
+        default: ""
+        type: string
+    secrets:
+      source_registry_username:
+        description: "Username for source_login_registry. Required only when source_login_registry is set."
+        required: false
+      source_registry_password:
+        description: "Password/PAT for source_login_registry. Required only when source_login_registry is set."
+        required: false
 
 jobs:
   mirror:
@@ -43,6 +55,24 @@ jobs:
     steps:
       - name: Set up crane
         uses: imjasonh/setup-crane@31b88efe9de28ae0ffa220711af4b60be9435f6e # v0.4
+
+      - name: Log in to source registry
+        # Only runs for authenticated sources (e.g. Docker Hardened Images on
+        # dhi.io). Anonymous public sources leave source_login_registry empty
+        # and skip this step entirely.
+        if: ${{ inputs.source_login_registry != '' }}
+        env:
+          SOURCE_LOGIN_REGISTRY: "${{ inputs.source_login_registry }}"
+          SOURCE_REGISTRY_USERNAME: "${{ secrets.source_registry_username }}"
+          SOURCE_REGISTRY_PASSWORD: "${{ secrets.source_registry_password }}"
+        run: |
+          set -euo pipefail
+          if [ -z "${SOURCE_REGISTRY_USERNAME}" ] || [ -z "${SOURCE_REGISTRY_PASSWORD}" ]; then
+            echo "::error::source_login_registry is set to '${SOURCE_LOGIN_REGISTRY}' but source_registry_username/source_registry_password were not provided."
+            exit 1
+          fi
+          echo "${SOURCE_REGISTRY_PASSWORD}" | crane auth login "${SOURCE_LOGIN_REGISTRY}" \
+            --username "${SOURCE_REGISTRY_USERNAME}" --password-stdin
 
       - name: Log in to GHCR
         run: |

--- a/.github/workflows/mirror-hardened-python.yml
+++ b/.github/workflows/mirror-hardened-python.yml
@@ -1,0 +1,48 @@
+# Mirror the Docker Hardened Image (DHI) python:3.14-alpine3.23 from dhi.io into
+# GHCR as quarantine/hardened/python.
+#
+# Unlike the public Docker Hub mirrors, DHI is served from the dhi.io registry
+# and requires authentication with Docker Hub credentials. This caller passes a
+# source_login_registry plus the DOCKERHUB_USERNAME / DOCKERHUB_TOKEN secrets to
+# the reusable _mirror-image.yml workflow, which performs the dhi.io login before
+# the digest-check-and-copy.
+#
+# Naming convention: "mirror-<image>.yml" for image mirror workflows. See
+# docs/contributing/workflow-naming.md.
+name: mirror / quarantine/hardened/python
+
+on:
+  # Daily upstream check at 06:00 UTC.
+  schedule:
+    - cron: "0 6 * * *"
+  # Manual run, with an optional force copy.
+  workflow_dispatch:
+    inputs:
+      force:
+        description: "Copy even when the source and destination digests match."
+        required: false
+        default: false
+        type: boolean
+
+# Avoid overlapping runs for this specific image mirror.
+concurrency:
+  group: mirror-quarantine-hardened-python
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  mirror-hardened-python:
+    uses: ./.github/workflows/_mirror-image.yml
+    with:
+      source_image: dhi.io/python
+      source_tag: 3.14-alpine3.23
+      source_login_registry: dhi.io
+      dest_image: ghcr.io/toddysm/quarantine/hardened/python
+      dest_tag: 3.14-alpine3.23
+      force: ${{ github.event_name == 'workflow_dispatch' && inputs.force || false }}
+    secrets:
+      source_registry_username: ${{ secrets.DOCKERHUB_USERNAME }}
+      source_registry_password: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/.github/workflows/scan-hardened-python.yml
+++ b/.github/workflows/scan-hardened-python.yml
@@ -6,6 +6,12 @@
 # workflow. The source image already lives in GHCR, so no dhi.io/Docker Hub
 # authentication is required here.
 #
+# Promotion target exception: this workflow promotes into "base/hardened/python"
+# rather than the "golden/<image>" scheme described in
+# docs/contributing/workflow-naming.md. Hardened (DHI) images are promoted into a
+# dedicated "base/hardened/<image>" namespace, so dest_repo intentionally does
+# NOT follow the golden/ convention.
+#
 # Naming convention: "scan-<image>.yml" for scan-and-promote workflows. See
 # docs/contributing/workflow-naming.md.
 name: scan / quarantine/hardened/python

--- a/.github/workflows/scan-hardened-python.yml
+++ b/.github/workflows/scan-hardened-python.yml
@@ -1,0 +1,60 @@
+# Scan quarantine/hardened/python with Trivy and promote clean images into
+# base/hardened/python.
+#
+# This caller only defines triggers and the repository-specific inputs; the
+# scan/gate/promote/attest/cleanup logic lives in the reusable _scan-image.yml
+# workflow. The source image already lives in GHCR, so no dhi.io/Docker Hub
+# authentication is required here.
+#
+# Naming convention: "scan-<image>.yml" for scan-and-promote workflows. See
+# docs/contributing/workflow-naming.md.
+name: scan / quarantine/hardened/python
+
+on:
+  # Daily scan at 07:00 UTC, after the 06:00 mirror has refreshed quarantine.
+  schedule:
+    - cron: "0 7 * * *"
+  # Manual run with policy overrides.
+  workflow_dispatch:
+    inputs:
+      severity_threshold:
+        description: "Blocking severity floor: LOW, MEDIUM, HIGH, or CRITICAL."
+        required: false
+        default: HIGH
+        type: choice
+        options:
+          - LOW
+          - MEDIUM
+          - HIGH
+          - CRITICAL
+      cve_exceptions:
+        description: "Pipe-separated allow-list of CVE IDs (e.g. CVE-2024-1234|CVE-2024-5678)."
+        required: false
+        default: ""
+        type: string
+      dry_run:
+        description: "Scan and report only; never copy, attach, or delete."
+        required: false
+        default: false
+        type: boolean
+
+# Avoid overlapping runs for this specific scan.
+concurrency:
+  group: scan-quarantine-hardened-python
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  scan-hardened-python:
+    uses: ./.github/workflows/_scan-image.yml
+    with:
+      source_repo: ghcr.io/toddysm/quarantine/hardened/python
+      dest_repo: ghcr.io/toddysm/base/hardened/python
+      severity_threshold: ${{ github.event_name == 'workflow_dispatch' && inputs.severity_threshold || 'HIGH' }}
+      cve_exceptions: ${{ github.event_name == 'workflow_dispatch' && inputs.cve_exceptions || '' }}
+      dry_run: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run || false }}
+    secrets:
+      ghcr_delete_token: ${{ secrets.GHCR_DELETE_TOKEN }}


### PR DESCRIPTION
## Summary

Adds a **mirror** workflow and a **scan-and-promote** workflow for the Docker
Hardened Image (DHI) `python:3.14-alpine3.23`, reusing the existing
caller + reusable-workflow pattern.

- **Source (DHI):** `dhi.io/python:3.14-alpine3.23` — pulled from `dhi.io`,
  which requires authentication with Docker Hub credentials.
- **Mirror destination (quarantine):** `ghcr.io/toddysm/quarantine/hardened/python`
- **Promotion destination (base):** `ghcr.io/toddysm/base/hardened/python`

## Changes

- **`_mirror-image.yml`** — optional, backward-compatible authenticated
  source-registry login. New input `source_login_registry` plus secrets
  `source_registry_username` / `source_registry_password`. The login step only
  runs when `source_login_registry` is set, so existing anonymous mirrors
  (python/node/openjdk) are unaffected.
- **`mirror-hardened-python.yml`** (new caller) — mirrors
  `dhi.io/python:3.14-alpine3.23` into `quarantine/hardened/python`, logging in
  to `dhi.io` with `DOCKERHUB_USERNAME` / `DOCKERHUB_TOKEN`.
- **`scan-hardened-python.yml`** (new caller) — scans
  `quarantine/hardened/python` and promotes passing tags into
  `base/hardened/python`. Reuses `_scan-image.yml` unchanged.

## Notes / follow-ups

- The request referenced tag `3.14-alpine3.2`; based on the catalog URL path
  (`python/alpine-3.23/3.14`) this PR uses `3.14-alpine3.23`. One-line edit if
  that needs changing.
- Repo secrets to configure before running: `DOCKERHUB_USERNAME`,
  `DOCKERHUB_TOKEN` (and `GHCR_DELETE_TOKEN` for scan cleanup, if not already set).

Closes #50
Closes #51
Closes #52