### PR TITLE
Fix mirror step failing after a successful copy

### DIFF
--- a/.github/workflows/_mirror-image.yml
+++ b/.github/workflows/_mirror-image.yml
@@ -213,5 +213,8 @@ jobs:
             echo "- **Destination:** \`${DEST_REF}\`"
             echo "- **Previous digest:** \`${dest_digest:-<none>}\`"
             echo "- **New digest:** \`${new_digest}\`"
-            [ -n "${referrers_note}" ] && echo "${referrers_note}"
+            # Use an `if` rather than `[ ... ] && echo`: the latter returns a
+            # non-zero status when referrers_note is empty, and as the final
+            # command in this step that would fail the job under `set -e`.
+            if [ -n "${referrers_note}" ]; then echo "${referrers_note}"; fi
           } >> "${GITHUB_STEP_SUMMARY}"


### PR DESCRIPTION
## Problem

The scheduled `mirror / quarantine/python` run [#27183374610](https://github.com/toddysm/cssc-framework/actions/runs/27183374610/job/80247036098) failed **after the image copied successfully** — the log shows `Copied. New destination digest: sha256:c845af93…` immediately followed by `##[error]Process completed with exit code 1`.

## Root cause

The job summary block in `_mirror-image.yml` ended with:

```sh
[ -n "${referrers_note}" ] && echo "${referrers_note}"
```

On the **standard mirror path** (no `copy_referrers`), `referrers_note` is empty, so `[ -n "" ]` returns a non-zero status. Because this was the **final command** in the step running under `set -euo pipefail`, that non-zero status became the step's exit code and failed the job — despite a successful copy.

It only surfaced now because the bug requires an actual copy to happen: when the source and destination digests matched, the step short-circuited earlier with `exit 0`. The `python:3.14-slim` upstream update changed the digest, triggering a real copy and exposing the latent bug.

## Fix

Replace the `[ ... ] && echo` shorthand with an `if`, which returns 0 when `referrers_note` is empty:

```sh
if [ -n "${referrers_note}" ]; then echo "${referrers_note}"; fi
```

## Validation

- `shellcheck -S warning` passes on the main script step (the only remaining finding is the known SC2296 false positive on the `${{ }}` login step).
- No other `[ ... ] && cmd` trailing-command hazards remain in the file.
- The referrer-aware path is unaffected (it sets `referrers_note`, so the `echo` runs either way).