### PR TITLE
Refactor workflows into reusable composite actions

### DIFF
--- a/.github/actions/attach-scan-report/action.yml
+++ b/.github/actions/attach-scan-report/action.yml
@@ -68,10 +68,10 @@ runs:
           --annotation "com.cssc.scan.exceptions=${EXCEPTED_STR}"
           --annotation "com.cssc.scan.scanner=trivy"
           --annotation "com.cssc.scan.scanner-version=${SCANNER_VERSION}"
+          --annotation "com.cssc.scan.method=${METHOD}"
         )
         if [ "${METHOD}" = "sbom" ]; then
           args+=(
-            --annotation "com.cssc.scan.method=sbom"
             --annotation "com.cssc.scan.sbom-predicate-type=${SBOM_PREDICATE_TYPE}"
           )
         fi

--- a/.github/actions/attach-scan-report/action.yml
+++ b/.github/actions/attach-scan-report/action.yml
@@ -1,0 +1,79 @@
+# Composite action: attach-scan-report
+#
+# Attach an empty OCI scan-report referrer to a promoted image with `oras
+# attach`. The referrer records how and when the image was cleared: its scan
+# method, source, tag, threshold, excepted CVEs, and scanner name/version. It
+# carries annotations only (no layer blobs); its subject is the promoted image.
+#
+# Terminology: see docs/reference/workflow-actions.md.
+name: attach-scan-report
+description: Attach an empty OCI scan-report referrer to a promoted image.
+
+inputs:
+  image-ref:
+    description: "Promoted image to attach the referrer to (repo:tag)."
+    required: true
+  source-repo:
+    description: "Repository the image was promoted from (recorded in the referrer)."
+    required: true
+  tag:
+    description: "Image tag that was scanned and promoted."
+    required: true
+  threshold:
+    description: "Severity threshold the image passed."
+    required: true
+  excepted-str:
+    description: "Pipe-separated CVEs cleared via the exception list (empty if none)."
+    required: false
+    default: ""
+  scanner-version:
+    description: "Resolved scanner (Trivy) version."
+    required: true
+  method:
+    description: "Scan method recorded in the referrer: 'image' or 'sbom'."
+    required: false
+    default: "image"
+  sbom-predicate-type:
+    description: "in-toto predicate type scanned; recorded only when method is 'sbom'."
+    required: false
+    default: ""
+
+runs:
+  using: composite
+  steps:
+    - name: Attach scan report to ${{ inputs.image-ref }}
+      shell: bash
+      env:
+        IMAGE_REF: "${{ inputs.image-ref }}"
+        SOURCE_REPO: "${{ inputs.source-repo }}"
+        TAG: "${{ inputs.tag }}"
+        THRESHOLD: "${{ inputs.threshold }}"
+        EXCEPTED_STR: "${{ inputs.excepted-str }}"
+        SCANNER_VERSION: "${{ inputs.scanner-version }}"
+        METHOD: "${{ inputs.method }}"
+        SBOM_PREDICATE_TYPE: "${{ inputs.sbom-predicate-type }}"
+      run: |
+        set -euo pipefail
+        export LC_ALL=C
+
+        created="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+        echo "Attaching scan report to ${IMAGE_REF}"
+
+        args=(
+          --artifact-type application/vnd.cssc.scan-report.v1+json
+          --annotation "org.opencontainers.image.created=${created}"
+          --annotation "com.cssc.scan.source=${SOURCE_REPO}"
+          --annotation "com.cssc.scan.tag=${TAG}"
+          --annotation "com.cssc.scan.threshold=${THRESHOLD}"
+          --annotation "com.cssc.scan.exceptions=${EXCEPTED_STR}"
+          --annotation "com.cssc.scan.scanner=trivy"
+          --annotation "com.cssc.scan.scanner-version=${SCANNER_VERSION}"
+        )
+        if [ "${METHOD}" = "sbom" ]; then
+          args+=(
+            --annotation "com.cssc.scan.method=sbom"
+            --annotation "com.cssc.scan.sbom-predicate-type=${SBOM_PREDICATE_TYPE}"
+          )
+        fi
+
+        oras attach "${args[@]}" "${IMAGE_REF}"

--- a/.github/actions/delete-image/action.yml
+++ b/.github/actions/delete-image/action.yml
@@ -1,0 +1,77 @@
+# Composite action: delete-image
+#
+# Delete one tag from a GHCR repository via the GitHub Packages REST API. The
+# built-in GITHUB_TOKEN can push and pull but cannot delete package versions, so
+# a PAT carrying `delete:packages` is required. Used to remove a tag from
+# quarantine after it has been promoted.
+#
+# Resolves the owner type (user vs organization) and the package-version id for
+# the tag, then issues the delete. Emits a status the caller can surface:
+# deleted | skipped | failed.
+#
+# Terminology: see docs/reference/workflow-actions.md.
+name: delete-image
+description: Delete one tag from a GHCR repository via the Packages REST API.
+
+inputs:
+  repository:
+    description: "GHCR repository the tag lives in, without tag (e.g. ghcr.io/owner/quarantine/python)."
+    required: true
+  tag:
+    description: "Tag to delete."
+    required: true
+  token:
+    description: "PAT with delete:packages. When empty, deletion is skipped with a warning."
+    required: false
+    default: ""
+
+outputs:
+  status:
+    description: "deleted | skipped | failed."
+    value: ${{ steps.delete.outputs.status }}
+
+runs:
+  using: composite
+  steps:
+    - name: Delete ${{ inputs.repository }}:${{ inputs.tag }}
+      id: delete
+      shell: bash
+      env:
+        REPOSITORY: "${{ inputs.repository }}"
+        TAG: "${{ inputs.tag }}"
+        DELETE_TOKEN: "${{ inputs.token }}"
+      run: |
+        set -euo pipefail
+        export LC_ALL=C
+
+        if [ -z "${DELETE_TOKEN}" ]; then
+          echo "::warning::No delete token provided; skipping deletion of ${REPOSITORY}:${TAG}."
+          echo "status=skipped" >> "${GITHUB_OUTPUT}"
+          exit 0
+        fi
+
+        # Work out the GHCR package coordinates: owner, encoded package path, and
+        # whether the owner is a user or an organization (different API base).
+        owner="$(printf '%s' "${REPOSITORY}" | awk -F/ '{print $2}')"
+        pkg_path="$(printf '%s' "${REPOSITORY}" | cut -d/ -f3-)"
+        pkg_enc="$(printf '%s' "${pkg_path}" | sed 's:/:%2F:g')"
+        owner_type="$(GH_TOKEN="${DELETE_TOKEN}" gh api "users/${owner}" --jq '.type' 2>/dev/null || true)"
+
+        if [ "${owner_type}" = "Organization" ]; then
+          base="orgs/${owner}/packages/container/${pkg_enc}"
+        else
+          base="user/packages/container/${pkg_enc}"
+        fi
+
+        vid="$(GH_TOKEN="${DELETE_TOKEN}" gh api --paginate "${base}/versions" \
+               --jq ".[] | select(.metadata.container.tags[]? == \"${TAG}\") | .id" 2>/dev/null \
+               | head -n1 || true)"
+        if [ -z "${vid}" ]; then
+          echo "::warning::Could not resolve a package version id for tag '${TAG}'; skipping deletion."
+          echo "status=failed" >> "${GITHUB_OUTPUT}"
+          exit 0
+        fi
+
+        GH_TOKEN="${DELETE_TOKEN}" gh api -X DELETE "${base}/versions/${vid}" >/dev/null
+        echo "Deleted ${REPOSITORY}:${TAG} (version ${vid})."
+        echo "status=deleted" >> "${GITHUB_OUTPUT}"

--- a/.github/actions/enumerate-tags/action.yml
+++ b/.github/actions/enumerate-tags/action.yml
@@ -1,0 +1,78 @@
+# Composite action: enumerate-tags
+#
+# List the tags in a container repository with crane, distinguishing an
+# empty / not-yet-created repository (expected; has-tags=false) from a real
+# failure such as an auth or transient registry error (fails loudly).
+#
+# Emits the tags as a JSON array so a calling workflow can fan them out across a
+# job matrix (strategy.matrix). Optionally filters out OCI referrer fallback
+# tags (sha256-*), which is needed when enumerating image tags in a repository
+# that also stores referrers as tags.
+#
+# Terminology: see docs/reference/workflow-actions.md.
+name: enumerate-tags
+description: List the tags in a container repository as a JSON array.
+
+inputs:
+  repository:
+    description: "Repository to enumerate, without a tag (e.g. ghcr.io/owner/quarantine/python)."
+    required: true
+  exclude-referrer-tags:
+    description: "Drop OCI referrer fallback tags (sha256-*) from the result."
+    required: false
+    default: "false"
+
+outputs:
+  tags-json:
+    description: "JSON array of tag names (empty array when the repository has no tags)."
+    value: ${{ steps.enumerate.outputs.tags-json }}
+  has-tags:
+    description: "'true' when at least one tag was found, otherwise 'false'."
+    value: ${{ steps.enumerate.outputs.has-tags }}
+
+runs:
+  using: composite
+  steps:
+    - name: Enumerate tags in ${{ inputs.repository }}
+      id: enumerate
+      shell: bash
+      env:
+        REPOSITORY: "${{ inputs.repository }}"
+        EXCLUDE_REFERRER_TAGS: "${{ inputs.exclude-referrer-tags }}"
+      run: |
+        set -euo pipefail
+        export LC_ALL=C
+
+        ls_err="$(mktemp)"
+        if all_tags="$(crane ls "${REPOSITORY}" 2>"${ls_err}")"; then
+          :
+        else
+          if grep -qiE 'NAME_UNKNOWN|not found|MANIFEST_UNKNOWN|UNAUTHORIZED.*not found|repository name not known' "${ls_err}"; then
+            echo "Repository ${REPOSITORY} has no tags yet; nothing to enumerate."
+            all_tags=""
+          else
+            echo "::error::Failed to list tags for ${REPOSITORY}:"
+            cat "${ls_err}" >&2
+            exit 1
+          fi
+        fi
+
+        if [ "${EXCLUDE_REFERRER_TAGS}" = "true" ]; then
+          tags="$(printf '%s\n' "${all_tags}" | grep -vE '^sha256-' || true)"
+        else
+          tags="${all_tags}"
+        fi
+
+        # Build a JSON array of non-empty tag names for matrix fan-out.
+        tags_json="$(printf '%s\n' "${tags}" \
+          | jq -R . | jq -s 'map(select(length > 0))' -c)"
+
+        if [ "${tags_json}" = "[]" ]; then
+          echo "No tags found in ${REPOSITORY}."
+          echo "tags-json=[]" >> "${GITHUB_OUTPUT}"
+          echo "has-tags=false" >> "${GITHUB_OUTPUT}"
+        else
+          echo "Found tags: ${tags_json}"
+          echo "tags-json=${tags_json}" >> "${GITHUB_OUTPUT}"
+          echo "has-tags=true" >> "${GITHUB_OUTPUT}"
+        fi

--- a/.github/actions/evaluate-findings/action.yml
+++ b/.github/actions/evaluate-findings/action.yml
@@ -1,0 +1,111 @@
+# Composite action: evaluate-findings
+#
+# Apply the promotion gate to one image's scan findings. Given the
+# de-duplicated list of vulnerability IDs a scanner reported (at or above the
+# severity floor) and a normalised CVE exception list, it computes the blocking,
+# excepted, and remaining sets and emits a single decision the promote / attest
+# / delete steps act on:
+#
+#   promote               remaining set empty and not a dry run
+#   dryrun                remaining set empty but dry_run is set
+#   blocked               one or more blocking CVEs remain after exceptions
+#   blocked-missing-sbom  an SBOM could not be read (scan-sbom only)
+#
+# Terminology: see docs/reference/workflow-actions.md.
+name: evaluate-findings
+description: Gate one image's findings on remaining blocking CVEs after exceptions.
+
+inputs:
+  blocking-ids-file:
+    description: "Newline-separated list of vulnerability IDs the scanner reported."
+    required: true
+  exceptions-file:
+    description: "Path to a sorted, de-duplicated file of excepted CVE IDs (may be empty)."
+    required: true
+  dry-run:
+    description: "When 'true', a passing image yields decision 'dryrun' instead of 'promote'."
+    required: false
+    default: "false"
+  missing-sbom-count:
+    description: "Number of platforms with an unreadable SBOM; non-zero forces 'blocked-missing-sbom'."
+    required: false
+    default: "0"
+  output-dir:
+    description: "Directory to write the computed gate files into."
+    required: true
+
+outputs:
+  decision:
+    description: "promote | dryrun | blocked | blocked-missing-sbom."
+    value: ${{ steps.gate.outputs.decision }}
+  blocking-count:
+    description: "Total distinct CVE IDs found at or above the threshold."
+    value: ${{ steps.gate.outputs.blocking-count }}
+  remaining-count:
+    description: "Blocking CVEs left after removing exceptions."
+    value: ${{ steps.gate.outputs.remaining-count }}
+  excepted-count:
+    description: "Blocking CVEs cleared by the exception list."
+    value: ${{ steps.gate.outputs.excepted-count }}
+  excepted-str:
+    description: "Pipe-separated excepted CVE IDs (for the scan-report annotation)."
+    value: ${{ steps.gate.outputs.excepted-str }}
+  remaining-md:
+    description: "Comma-separated remaining CVE IDs for Markdown summaries."
+    value: ${{ steps.gate.outputs.remaining-md }}
+  excepted-md:
+    description: "Comma-separated excepted CVE IDs for Markdown summaries."
+    value: ${{ steps.gate.outputs.excepted-md }}
+
+runs:
+  using: composite
+  steps:
+    - name: Evaluate findings against the gate
+      id: gate
+      shell: bash
+      env:
+        BLOCKING_IDS_FILE: "${{ inputs.blocking-ids-file }}"
+        EXCEPTIONS_FILE: "${{ inputs.exceptions-file }}"
+        DRY_RUN: "${{ inputs.dry-run }}"
+        MISSING_SBOM_COUNT: "${{ inputs.missing-sbom-count }}"
+        OUTPUT_DIR: "${{ inputs.output-dir }}"
+      run: |
+        set -euo pipefail
+        export LC_ALL=C
+
+        mkdir -p "${OUTPUT_DIR}"
+
+        sort -u "${BLOCKING_IDS_FILE}" > "${OUTPUT_DIR}/blocking.txt"
+        comm -23 "${OUTPUT_DIR}/blocking.txt" "${EXCEPTIONS_FILE}" > "${OUTPUT_DIR}/remaining.txt"
+        comm -12 "${OUTPUT_DIR}/blocking.txt" "${EXCEPTIONS_FILE}" > "${OUTPUT_DIR}/excepted.txt"
+
+        blocking_count="$(wc -l < "${OUTPUT_DIR}/blocking.txt" | tr -d ' ')"
+        remaining_count="$(wc -l < "${OUTPUT_DIR}/remaining.txt" | tr -d ' ')"
+        excepted_count="$(wc -l < "${OUTPUT_DIR}/excepted.txt" | tr -d ' ')"
+
+        # Pipe-separated form for the oras annotation; comma-separated,
+        # Markdown-safe forms for the summary tables (CVE IDs contain no '|').
+        excepted_str="$(paste -sd '|' "${OUTPUT_DIR}/excepted.txt")"
+        remaining_md="$(paste -sd ',' "${OUTPUT_DIR}/remaining.txt" | sed 's/,/, /g')"
+        excepted_md="$(paste -sd ',' "${OUTPUT_DIR}/excepted.txt" | sed 's/,/, /g')"
+
+        if [ "${MISSING_SBOM_COUNT}" -gt 0 ]; then
+          decision="blocked-missing-sbom"
+        elif [ "${remaining_count}" -gt 0 ]; then
+          decision="blocked"
+        elif [ "${DRY_RUN}" = "true" ]; then
+          decision="dryrun"
+        else
+          decision="promote"
+        fi
+        echo "Gate decision: ${decision} (blocking ${remaining_count}, excepted ${excepted_count}, missing SBOM ${MISSING_SBOM_COUNT})"
+
+        {
+          echo "decision=${decision}"
+          echo "blocking-count=${blocking_count}"
+          echo "remaining-count=${remaining_count}"
+          echo "excepted-count=${excepted_count}"
+          echo "excepted-str=${excepted_str}"
+          echo "remaining-md=${remaining_md}"
+          echo "excepted-md=${excepted_md}"
+        } >> "${GITHUB_OUTPUT}"

--- a/.github/actions/mirror-image/action.yml
+++ b/.github/actions/mirror-image/action.yml
@@ -1,0 +1,169 @@
+# Composite action: mirror-image
+#
+# Copy a single container image from a source ref to a destination ref. The copy
+# is idempotent: unless `force` is set, the source and destination digests are
+# compared and the copy is skipped when they already match. `crane copy`
+# preserves multi-architecture manifest lists.
+#
+# When `copy-referrers` is true the copy is performed with `oras cp -r` instead,
+# carrying the image graph and all OCI referrers (SBOMs, provenance, VEX,
+# signatures) for the index and each per-platform child manifest, with retry to
+# absorb transient registry errors. In that mode the digest short-circuit is
+# always skipped, because referrers can change independently of the subject
+# digest.
+#
+# This action backs both the upstream -> quarantine mirror and the
+# quarantine -> golden/base promotion (promotion is a mirror with force=true).
+#
+# Terminology: see docs/reference/workflow-actions.md.
+name: mirror-image
+description: Idempotently copy one image (optionally with its referrers) between registries.
+
+inputs:
+  source-image:
+    description: "Fully qualified source image without tag (e.g. docker.io/library/python)."
+    required: true
+  source-tag:
+    description: "Source image tag (e.g. 3.14-slim)."
+    required: true
+  dest-image:
+    description: "Fully qualified destination image without tag (e.g. ghcr.io/owner/quarantine/python)."
+    required: true
+  dest-tag:
+    description: "Destination image tag."
+    required: true
+  force:
+    description: "Copy even when the source and destination digests match."
+    required: false
+    default: "false"
+  copy-referrers:
+    description: "Copy OCI referrers (SBOMs/provenance/VEX/signatures) with oras instead of a plain crane copy."
+    required: false
+    default: "false"
+
+outputs:
+  copied:
+    description: "'true' when a copy was performed, 'false' when the destination was already up to date."
+    value: ${{ steps.mirror.outputs.copied }}
+  digest:
+    description: "Digest of the image at the destination after the action ran."
+    value: ${{ steps.mirror.outputs.digest }}
+  previous-digest:
+    description: "Digest previously at the destination ('<none>' when it did not exist)."
+    value: ${{ steps.mirror.outputs.previous-digest }}
+  referrers-note:
+    description: "Human-readable note about copied referrers (empty when copy-referrers is false)."
+    value: ${{ steps.mirror.outputs.referrers-note }}
+
+runs:
+  using: composite
+  steps:
+    - name: Mirror ${{ inputs.source-image }}:${{ inputs.source-tag }} -> ${{ inputs.dest-image }}:${{ inputs.dest-tag }}
+      id: mirror
+      shell: bash
+      env:
+        SOURCE_IMAGE: "${{ inputs.source-image }}"
+        DEST_IMAGE: "${{ inputs.dest-image }}"
+        SOURCE_REF: "${{ inputs.source-image }}:${{ inputs.source-tag }}"
+        DEST_REF: "${{ inputs.dest-image }}:${{ inputs.dest-tag }}"
+        FORCE: "${{ inputs.force }}"
+        COPY_REFERRERS: "${{ inputs.copy-referrers }}"
+      run: |
+        set -euo pipefail
+
+        echo "Source:      ${SOURCE_REF}"
+        echo "Destination: ${DEST_REF}"
+
+        source_digest="$(crane digest "${SOURCE_REF}")"
+        echo "Source digest:      ${source_digest}"
+
+        if dest_digest="$(crane digest "${DEST_REF}" 2>/dev/null)"; then
+          echo "Destination digest: ${dest_digest}"
+        else
+          dest_digest=""
+          echo "Destination digest: <not present>"
+        fi
+
+        # The digest short-circuit is intentionally skipped when copying
+        # referrers: OCI referrers (SBOM/VEX/provenance/signatures) can change
+        # independently of the subject manifest digest, so a matching image
+        # digest does not guarantee the referrers are in sync. In that mode we
+        # always re-run the referrer-aware copy (oras cp is itself idempotent).
+        if [ "${FORCE}" != "true" ] && [ "${COPY_REFERRERS}" != "true" ] && [ "${source_digest}" = "${dest_digest}" ]; then
+          echo "Image is already up to date; nothing to copy."
+          {
+            echo "copied=false"
+            echo "digest=${source_digest}"
+            echo "previous-digest=${dest_digest:-<none>}"
+            echo "referrers-note="
+          } >> "${GITHUB_OUTPUT}"
+          exit 0
+        fi
+
+        if [ "${FORCE}" = "true" ]; then
+          echo "Force enabled; copying regardless of digest match."
+        elif [ "${COPY_REFERRERS}" = "true" ] && [ "${source_digest}" = "${dest_digest}" ]; then
+          echo "Image digest matches, but copy-referrers is enabled; re-syncing image and referrers."
+        else
+          echo "Digests differ; copying updated image."
+        fi
+
+        referrers_note=""
+        if [ "${COPY_REFERRERS}" = "true" ]; then
+          # Some registries (notably dhi.io) intermittently return transient
+          # "not found"/5xx errors while oras fans out the many blob requests an
+          # `oras cp -r` makes. Retry the copy a few times with backoff so a
+          # single flaky response does not fail the whole mirror.
+          oras_cp_retry() {
+            local attempt=1 max=4 delay=5
+            while true; do
+              if oras cp -r "$1" "$2"; then
+                return 0
+              fi
+              if [ "${attempt}" -ge "${max}" ]; then
+                echo "::error::oras cp -r '$1' -> '$2' failed after ${max} attempts."
+                return 1
+              fi
+              echo "::warning::oras cp -r '$1' -> '$2' failed (attempt ${attempt}/${max}); retrying in ${delay}s."
+              sleep "${delay}"
+              attempt=$((attempt + 1))
+              delay=$((delay * 2))
+            done
+          }
+
+          # Copy the image graph and all referrers with oras. `oras cp -r` copies
+          # the index, its child manifests/blobs, and the referrers of the index
+          # itself.
+          echo "Copying image and referrers with oras."
+          oras_cp_retry "${SOURCE_REF}" "${DEST_REF}"
+
+          # Referrers attached to each per-platform child manifest (e.g. DHI
+          # cosign SBOM/provenance/VEX attestations whose subject is a platform
+          # digest) are not pulled by the index-level copy, so copy each child
+          # manifest and its referrers explicitly. Digests are preserved, so
+          # every referrer's subject link stays valid against the copied image.
+          child_digests="$(crane manifest "${SOURCE_REF}" | jq -r '.manifests[]?.digest // empty')"
+          child_count=0
+          for d in ${child_digests}; do
+            [ -n "${d}" ] || continue
+            echo "Copying child manifest ${d} and its referrers."
+            oras_cp_retry "${SOURCE_IMAGE}@${d}" "${DEST_IMAGE}@${d}"
+            child_count=$((child_count + 1))
+          done
+
+          # Best-effort count of referrers now on the destination image.
+          ref_count="$(oras discover --format json "${DEST_REF}" 2>/dev/null \
+            | jq '[.. | objects | select(has("artifactType")) | .artifactType] | length' 2>/dev/null || echo "")"
+          referrers_note="copied (child manifests processed: ${child_count}${ref_count:+, image-level referrers: ${ref_count}})"
+        else
+          crane copy "${SOURCE_REF}" "${DEST_REF}"
+        fi
+
+        new_digest="$(crane digest "${DEST_REF}")"
+        echo "Copied. New destination digest: ${new_digest}"
+        {
+          echo "copied=true"
+          echo "digest=${new_digest}"
+          echo "previous-digest=${dest_digest:-<none>}"
+          echo "referrers-note=${referrers_note}"
+        } >> "${GITHUB_OUTPUT}"

--- a/.github/actions/registry-login/action.yml
+++ b/.github/actions/registry-login/action.yml
@@ -1,0 +1,47 @@
+# Composite action: registry-login
+#
+# Authenticate the local crane (and, optionally, oras) clients to a container
+# registry using a username + password/token. Used to log in to GHCR with the
+# built-in GITHUB_TOKEN and to authenticated upstream sources such as dhi.io.
+#
+# Terminology: see docs/reference/workflow-actions.md.
+name: registry-login
+description: Log in to a container registry with crane (and optionally oras).
+
+inputs:
+  registry:
+    description: "Registry hostname to authenticate to (e.g. ghcr.io, dhi.io)."
+    required: true
+  username:
+    description: "Username for the registry."
+    required: true
+  password:
+    description: "Password or token for the registry (passed via stdin)."
+    required: true
+  with-oras:
+    description: "Also log in oras (needed when copying referrers or attaching artifacts)."
+    required: false
+    default: "false"
+
+runs:
+  using: composite
+  steps:
+    - name: Log in to ${{ inputs.registry }}
+      shell: bash
+      env:
+        REGISTRY: "${{ inputs.registry }}"
+        USERNAME: "${{ inputs.username }}"
+        PASSWORD: "${{ inputs.password }}"
+        WITH_ORAS: "${{ inputs.with-oras }}"
+      run: |
+        set -euo pipefail
+        if [ -z "${USERNAME}" ] || [ -z "${PASSWORD}" ]; then
+          echo "::error::registry-login requires a non-empty username and password for '${REGISTRY}'."
+          exit 1
+        fi
+        echo "${PASSWORD}" | crane auth login "${REGISTRY}" \
+          --username "${USERNAME}" --password-stdin
+        if [ "${WITH_ORAS}" = "true" ]; then
+          echo "${PASSWORD}" | oras login "${REGISTRY}" \
+            --username "${USERNAME}" --password-stdin
+        fi

--- a/.github/actions/scan-image/action.yml
+++ b/.github/actions/scan-image/action.yml
@@ -1,0 +1,58 @@
+# Composite action: scan-image
+#
+# Scan a single container image's filesystem with `trivy image` and write the
+# JSON report plus the de-duplicated list of vulnerability IDs found at or above
+# the requested severity set. Suited to images that carry package-manager
+# metadata; for distroless / hardened images use scan-sbom instead.
+#
+# Terminology: see docs/reference/workflow-actions.md.
+name: scan-image
+description: Scan one image filesystem with trivy image and emit its findings.
+
+inputs:
+  image-ref:
+    description: "Fully qualified image reference to scan (repo:tag)."
+    required: true
+  severities:
+    description: "Comma-separated severities to report (e.g. HIGH,CRITICAL)."
+    required: true
+  output-dir:
+    description: "Directory to write report.json and blocking-ids.txt into."
+    required: true
+
+outputs:
+  report-path:
+    description: "Path to the Trivy JSON report."
+    value: ${{ steps.scan.outputs.report-path }}
+  blocking-ids-path:
+    description: "Path to the newline-separated, de-duplicated list of vulnerability IDs found."
+    value: ${{ steps.scan.outputs.blocking-ids-path }}
+
+runs:
+  using: composite
+  steps:
+    - name: Scan ${{ inputs.image-ref }} with trivy image
+      id: scan
+      shell: bash
+      env:
+        IMAGE_REF: "${{ inputs.image-ref }}"
+        SEVERITIES: "${{ inputs.severities }}"
+        OUTPUT_DIR: "${{ inputs.output-dir }}"
+      run: |
+        set -euo pipefail
+        export LC_ALL=C
+
+        mkdir -p "${OUTPUT_DIR}"
+        report="${OUTPUT_DIR}/report.json"
+        ids="${OUTPUT_DIR}/blocking-ids.txt"
+
+        echo "::group::Scanning ${IMAGE_REF}"
+        trivy image --quiet --scanners vuln --severity "${SEVERITIES}" \
+          --format json --output "${report}" "${IMAGE_REF}"
+        echo "::endgroup::"
+
+        jq -r '[.Results[]?.Vulnerabilities[]?.VulnerabilityID] | unique | .[]' \
+          "${report}" | sort -u > "${ids}"
+
+        echo "report-path=${report}" >> "${GITHUB_OUTPUT}"
+        echo "blocking-ids-path=${ids}" >> "${GITHUB_OUTPUT}"

--- a/.github/actions/scan-sbom/action.yml
+++ b/.github/actions/scan-sbom/action.yml
@@ -159,6 +159,10 @@ runs:
         done < "${platforms_file}"
         echo "::endgroup::"
 
+        # De-duplicate the cross-platform union so the same CVE found on several
+        # platforms is reported once (matches the documented output semantics).
+        sort -u "${tag_blocking}" -o "${tag_blocking}"
+
         echo "missing-sbom-count=${missing_sbom}" >> "${GITHUB_OUTPUT}"
         echo "platform-count=${platform_count}" >> "${GITHUB_OUTPUT}"
         echo "blocking-ids-path=${tag_blocking}" >> "${GITHUB_OUTPUT}"

--- a/.github/actions/scan-sbom/action.yml
+++ b/.github/actions/scan-sbom/action.yml
@@ -1,0 +1,165 @@
+# Composite action: scan-sbom
+#
+# Scan a single container image via its SBOM attestation rather than its
+# filesystem. Built for distroless / hardened images (e.g. Docker Hardened
+# Images) that carry no package-manager metadata. For every platform in the
+# image index it locates the SBOM referrer whose in-toto predicate type matches
+# `sbom-predicate-type`, extracts the embedded BOM, and scans it with
+# `trivy sbom`.
+#
+# Emits the union of vulnerability IDs across all platforms, the number of
+# platforms whose SBOM could not be found (a blocking condition), the platform
+# count, and a Markdown fragment with the per-platform breakdown.
+#
+# Terminology: see docs/reference/workflow-actions.md.
+name: scan-sbom
+description: Scan one image's per-platform SBOM attestations with trivy sbom.
+
+inputs:
+  image-ref:
+    description: "Fully qualified image reference to scan (repo:tag)."
+    required: true
+  repository:
+    description: "Repository the image lives in, without tag (used to fetch referrers by digest)."
+    required: true
+  severities:
+    description: "Comma-separated severities to report (e.g. HIGH,CRITICAL)."
+    required: true
+  sbom-predicate-type:
+    description: "in-toto predicate type of the SBOM attestation to scan (e.g. https://cyclonedx.org/bom/v1.6)."
+    required: true
+  exceptions-file:
+    description: "Path to a sorted file of excepted CVE IDs; used only to render the per-platform blocking breakdown."
+    required: true
+  output-dir:
+    description: "Directory to write SBOMs, reports, and the blocking-ids list into."
+    required: true
+
+outputs:
+  blocking-ids-path:
+    description: "Path to the newline-separated union of vulnerability IDs across platforms."
+    value: ${{ steps.scan.outputs.blocking-ids-path }}
+  missing-sbom-count:
+    description: "Number of platforms with no SBOM referrer of the requested predicate type."
+    value: ${{ steps.scan.outputs.missing-sbom-count }}
+  platform-count:
+    description: "Number of platforms inspected."
+    value: ${{ steps.scan.outputs.platform-count }}
+  platform-detail-path:
+    description: "Path to a Markdown fragment with the per-platform findings table rows."
+    value: ${{ steps.scan.outputs.platform-detail-path }}
+
+runs:
+  using: composite
+  steps:
+    - name: Scan SBOMs for ${{ inputs.image-ref }} with trivy sbom
+      id: scan
+      shell: bash
+      env:
+        IMAGE_REF: "${{ inputs.image-ref }}"
+        REPOSITORY: "${{ inputs.repository }}"
+        SEVERITIES: "${{ inputs.severities }}"
+        SBOM_PREDICATE_TYPE: "${{ inputs.sbom-predicate-type }}"
+        EXCEPTIONS_FILE: "${{ inputs.exceptions-file }}"
+        OUTPUT_DIR: "${{ inputs.output-dir }}"
+      run: |
+        set -euo pipefail
+        export LC_ALL=C
+
+        mkdir -p "${OUTPUT_DIR}"
+
+        # --- Extract the SBOM predicate for one platform manifest. ------------
+        # Echoes the path to a written SBOM file on success; returns non-zero
+        # when no SBOM referrer of the requested predicate type is found.
+        extract_platform_sbom() {
+          local plat_digest="$1" out="$2" ref_digest layer_digest stmt
+          ref_digest="$(oras discover --format json "${REPOSITORY}@${plat_digest}" 2>/dev/null \
+            | jq -r --arg PT "${SBOM_PREDICATE_TYPE}" '
+                [.. | objects | select(.artifactType? == "application/vnd.in-toto+json")]
+                | map(select(.annotations["in-toto.io/predicate-type"] == $PT))
+                | .[0].digest // empty')"
+          [ -n "${ref_digest}" ] || return 1
+          layer_digest="$(oras manifest fetch "${REPOSITORY}@${ref_digest}" \
+            | jq -r '.layers[0].digest // empty')"
+          [ -n "${layer_digest}" ] || return 1
+          stmt="${OUTPUT_DIR}/stmt.json"
+          oras blob fetch --output "${stmt}" "${REPOSITORY}@${layer_digest}"
+          # The blob is an in-toto Statement (DHI) or a DSSE envelope wrapping
+          # one. Extract the `.predicate` (the actual CycloneDX/SPDX BOM).
+          if jq -e '.payload and .payloadType' "${stmt}" >/dev/null 2>&1; then
+            jq -r '.payload' "${stmt}" | base64 -d | jq '.predicate' > "${out}"
+          else
+            jq '.predicate' "${stmt}" > "${out}"
+          fi
+          [ -s "${out}" ] || return 1
+          return 0
+        }
+
+        src="${IMAGE_REF}"
+        echo "::group::Scanning SBOMs for ${src}"
+
+        # --- Determine the platforms to scan. --------------------------------
+        manifest_json="$(crane manifest "${src}")"
+        media_type="$(printf '%s' "${manifest_json}" | jq -r '.mediaType // empty')"
+        platforms_file="${OUTPUT_DIR}/platforms.tsv"   # digest<TAB>platform
+        : > "${platforms_file}"
+        case "${media_type}" in
+          *image.index*|*manifest.list*)
+            printf '%s' "${manifest_json}" | jq -r '
+              .manifests[]
+              | select((.platform.os // "") != "" and (.platform.os // "") != "unknown")
+              | [ .digest, "\(.platform.os)/\(.platform.architecture)\(if .platform.variant then "/"+.platform.variant else "" end)" ]
+              | @tsv' >> "${platforms_file}"
+            ;;
+          *)
+            printf '%s\t%s\n' "$(crane digest "${src}")" "single" >> "${platforms_file}"
+            ;;
+        esac
+
+        tag_blocking="${OUTPUT_DIR}/blocking-ids.txt"   # union across platforms
+        : > "${tag_blocking}"
+        plat_detail="${OUTPUT_DIR}/platdetail.md"
+        : > "${plat_detail}"
+        missing_sbom=0
+        platform_count=0
+
+        while IFS="$(printf '\t')" read -r plat_digest plat_name; do
+          [ -n "${plat_digest}" ] || continue
+          platform_count=$((platform_count + 1))
+          echo "Platform ${plat_name} (${plat_digest})"
+
+          sbom_file="${OUTPUT_DIR}/sbom-$(printf '%s' "${plat_name}" | tr '/' '_').json"
+          if ! extract_platform_sbom "${plat_digest}" "${sbom_file}"; then
+            echo "::warning::No SBOM referrer of type ${SBOM_PREDICATE_TYPE} found for ${src} (${plat_name})."
+            missing_sbom=$((missing_sbom + 1))
+            printf '| `%s` | :warning: no SBOM | — | — |\n' "${plat_name}" >> "${plat_detail}"
+            continue
+          fi
+
+          report="${OUTPUT_DIR}/report-$(printf '%s' "${plat_name}" | tr '/' '_').json"
+          trivy sbom --quiet --scanners vuln --severity "${SEVERITIES}" \
+            --format json --output "${report}" "${sbom_file}"
+
+          plat_ids="${OUTPUT_DIR}/ids.txt"
+          jq -r '[.Results[]?.Vulnerabilities[]?.VulnerabilityID] | unique | .[]' \
+            "${report}" | sort -u > "${plat_ids}"
+          cat "${plat_ids}" >> "${tag_blocking}"
+
+          # Per-platform counts that mirror the gate: total findings at/above
+          # the threshold, and the blocking subset after removing exceptions.
+          plat_total_ids="${OUTPUT_DIR}/plattotal.txt"
+          plat_block_ids="${OUTPUT_DIR}/platblock.txt"
+          sort -u "${plat_ids}" > "${plat_total_ids}"
+          comm -23 "${plat_total_ids}" "${EXCEPTIONS_FILE}" > "${plat_block_ids}"
+          plat_total="$(wc -l < "${plat_total_ids}" | tr -d ' ')"
+          plat_block="$(wc -l < "${plat_block_ids}" | tr -d ' ')"
+          plat_block_list="$(paste -sd ',' "${plat_block_ids}" | sed 's/,/, /g')"
+          printf '| `%s` | %s | %s | %s |\n' \
+            "${plat_name}" "${plat_total}" "${plat_block}" "${plat_block_list:-—}" >> "${plat_detail}"
+        done < "${platforms_file}"
+        echo "::endgroup::"
+
+        echo "missing-sbom-count=${missing_sbom}" >> "${GITHUB_OUTPUT}"
+        echo "platform-count=${platform_count}" >> "${GITHUB_OUTPUT}"
+        echo "blocking-ids-path=${tag_blocking}" >> "${GITHUB_OUTPUT}"
+        echo "platform-detail-path=${plat_detail}" >> "${GITHUB_OUTPUT}"

--- a/.github/workflows/_mirror-image.yml
+++ b/.github/workflows/_mirror-image.yml
@@ -4,9 +4,13 @@
 # not meant to be triggered directly. It is called by per-image "mirror-*"
 # workflows via `uses:`.
 #
-# It performs an idempotent sync: on every run it compares the digest of the
-# source tag with the digest already present in the destination, and only copies
-# when they differ. crane copy preserves multi-architecture manifest lists.
+# It orchestrates the shared composite actions under .github/actions/ to perform
+# an idempotent sync: log in (registry-login), then compare the source and
+# destination digests and copy only when they differ (mirror-image). crane copy
+# preserves multi-architecture manifest lists; with copy_referrers it switches to
+# an oras-based copy that also carries OCI referrers.
+#
+# Terminology and the action catalogue: see docs/reference/workflow-actions.md.
 name: _reusable / mirror-image
 
 on:
@@ -58,6 +62,9 @@ jobs:
       contents: read
       packages: write
     steps:
+      - name: Check out actions
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
       - name: Set up crane
         uses: imjasonh/setup-crane@31b88efe9de28ae0ffa220711af4b60be9435f6e # v0.4
 
@@ -74,147 +81,58 @@ jobs:
         # dhi.io). Anonymous public sources leave source_login_registry empty
         # and skip this step entirely.
         if: ${{ inputs.source_login_registry != '' }}
-        env:
-          SOURCE_LOGIN_REGISTRY: "${{ inputs.source_login_registry }}"
-          SOURCE_REGISTRY_USERNAME: "${{ secrets.source_registry_username }}"
-          SOURCE_REGISTRY_PASSWORD: "${{ secrets.source_registry_password }}"
-          COPY_REFERRERS: "${{ inputs.copy_referrers }}"
-        run: |
-          set -euo pipefail
-          if [ -z "${SOURCE_REGISTRY_USERNAME}" ] || [ -z "${SOURCE_REGISTRY_PASSWORD}" ]; then
-            echo "::error::source_login_registry is set to '${SOURCE_LOGIN_REGISTRY}' but source_registry_username/source_registry_password were not provided."
-            exit 1
-          fi
-          echo "${SOURCE_REGISTRY_PASSWORD}" | crane auth login "${SOURCE_LOGIN_REGISTRY}" \
-            --username "${SOURCE_REGISTRY_USERNAME}" --password-stdin
-          if [ "${COPY_REFERRERS}" = "true" ]; then
-            echo "${SOURCE_REGISTRY_PASSWORD}" | oras login "${SOURCE_LOGIN_REGISTRY}" \
-              --username "${SOURCE_REGISTRY_USERNAME}" --password-stdin
-          fi
+        uses: ./.github/actions/registry-login
+        with:
+          registry: ${{ inputs.source_login_registry }}
+          username: ${{ secrets.source_registry_username }}
+          password: ${{ secrets.source_registry_password }}
+          with-oras: ${{ inputs.copy_referrers }}
 
       - name: Log in to GHCR
-        env:
-          COPY_REFERRERS: "${{ inputs.copy_referrers }}"
-        run: |
-          set -euo pipefail
-          echo "${{ github.token }}" | crane auth login ghcr.io \
-            --username "${{ github.actor }}" --password-stdin
-          if [ "${COPY_REFERRERS}" = "true" ]; then
-            echo "${{ github.token }}" | oras login ghcr.io \
-              --username "${{ github.actor }}" --password-stdin
-          fi
+        uses: ./.github/actions/registry-login
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ github.token }}
+          with-oras: ${{ inputs.copy_referrers }}
 
-      - name: Compare digests and copy if changed
+      - name: Mirror image
+        id: mirror
+        uses: ./.github/actions/mirror-image
+        with:
+          source-image: ${{ inputs.source_image }}
+          source-tag: ${{ inputs.source_tag }}
+          dest-image: ${{ inputs.dest_image }}
+          dest-tag: ${{ inputs.dest_tag }}
+          force: ${{ inputs.force }}
+          copy-referrers: ${{ inputs.copy_referrers }}
+
+      - name: Write job summary
         env:
-          SOURCE_IMAGE: "${{ inputs.source_image }}"
-          DEST_IMAGE: "${{ inputs.dest_image }}"
           SOURCE_REF: "${{ inputs.source_image }}:${{ inputs.source_tag }}"
           DEST_REF: "${{ inputs.dest_image }}:${{ inputs.dest_tag }}"
-          FORCE: "${{ inputs.force }}"
-          COPY_REFERRERS: "${{ inputs.copy_referrers }}"
+          COPIED: "${{ steps.mirror.outputs.copied }}"
+          DIGEST: "${{ steps.mirror.outputs.digest }}"
+          PREVIOUS_DIGEST: "${{ steps.mirror.outputs.previous-digest }}"
+          REFERRERS_NOTE: "${{ steps.mirror.outputs.referrers-note }}"
         run: |
           set -euo pipefail
-
-          echo "Source:      ${SOURCE_REF}"
-          echo "Destination: ${DEST_REF}"
-
-          source_digest="$(crane digest "${SOURCE_REF}")"
-          echo "Source digest:      ${source_digest}"
-
-          if dest_digest="$(crane digest "${DEST_REF}" 2>/dev/null)"; then
-            echo "Destination digest: ${dest_digest}"
+          if [ "${COPIED}" = "true" ]; then
+            {
+              echo "### Mirror image: copied :inbox_tray:"
+              echo ""
+              echo "- **Source:** \`${SOURCE_REF}\`"
+              echo "- **Destination:** \`${DEST_REF}\`"
+              echo "- **Previous digest:** \`${PREVIOUS_DIGEST}\`"
+              echo "- **New digest:** \`${DIGEST}\`"
+              if [ -n "${REFERRERS_NOTE}" ]; then echo "- **Referrers:** ${REFERRERS_NOTE}"; fi
+            } >> "${GITHUB_STEP_SUMMARY}"
           else
-            dest_digest=""
-            echo "Destination digest: <not present>"
-          fi
-
-          # The digest short-circuit is intentionally skipped when copying
-          # referrers: OCI referrers (SBOM/VEX/provenance/signatures) can change
-          # independently of the subject manifest digest, so a matching image
-          # digest does not guarantee the referrers are in sync. In that mode we
-          # always re-run the referrer-aware copy (oras cp is itself idempotent).
-          if [ "${FORCE}" != "true" ] && [ "${COPY_REFERRERS}" != "true" ] && [ "${source_digest}" = "${dest_digest}" ]; then
-            echo "Image is already up to date; nothing to copy."
             {
               echo "### Mirror image: up to date :white_check_mark:"
               echo ""
               echo "- **Source:** \`${SOURCE_REF}\`"
               echo "- **Destination:** \`${DEST_REF}\`"
-              echo "- **Digest:** \`${source_digest}\`"
+              echo "- **Digest:** \`${DIGEST}\`"
             } >> "${GITHUB_STEP_SUMMARY}"
-            exit 0
           fi
-
-          if [ "${FORCE}" = "true" ]; then
-            echo "Force enabled; copying regardless of digest match."
-          elif [ "${COPY_REFERRERS}" = "true" ] && [ "${source_digest}" = "${dest_digest}" ]; then
-            echo "Image digest matches, but copy_referrers is enabled; re-syncing image and referrers."
-          else
-            echo "Digests differ; copying updated image."
-          fi
-
-          referrers_note=""
-          if [ "${COPY_REFERRERS}" = "true" ]; then
-            # Some registries (notably dhi.io) intermittently return transient
-            # "not found"/5xx errors while oras fans out the many blob requests
-            # an `oras cp -r` makes. Retry the copy a few times with backoff so a
-            # single flaky response does not fail the whole mirror.
-            oras_cp_retry() {
-              local attempt=1 max=4 delay=5
-              while true; do
-                if oras cp -r "$1" "$2"; then
-                  return 0
-                fi
-                if [ "${attempt}" -ge "${max}" ]; then
-                  echo "::error::oras cp -r '$1' -> '$2' failed after ${max} attempts."
-                  return 1
-                fi
-                echo "::warning::oras cp -r '$1' -> '$2' failed (attempt ${attempt}/${max}); retrying in ${delay}s."
-                sleep "${delay}"
-                attempt=$((attempt + 1))
-                delay=$((delay * 2))
-              done
-            }
-
-            # Copy the image graph and all referrers with oras. `oras cp -r`
-            # copies the index, its child manifests/blobs, and the referrers of
-            # the index itself.
-            echo "Copying image and referrers with oras."
-            oras_cp_retry "${SOURCE_REF}" "${DEST_REF}"
-
-            # Referrers attached to each per-platform child manifest (e.g. DHI
-            # cosign SBOM/provenance/VEX attestations whose subject is a platform
-            # digest) are not pulled by the index-level copy, so copy each child
-            # manifest and its referrers explicitly. Digests are preserved, so
-            # every referrer's subject link stays valid against the copied image.
-            child_digests="$(crane manifest "${SOURCE_REF}" | jq -r '.manifests[]?.digest // empty')"
-            child_count=0
-            for d in ${child_digests}; do
-              [ -n "${d}" ] || continue
-              echo "Copying child manifest ${d} and its referrers."
-              oras_cp_retry "${SOURCE_IMAGE}@${d}" "${DEST_IMAGE}@${d}"
-              child_count=$((child_count + 1))
-            done
-
-            # Best-effort count of referrers now on the destination image.
-            ref_count="$(oras discover --format json "${DEST_REF}" 2>/dev/null \
-              | jq '[.. | objects | select(has("artifactType")) | .artifactType] | length' 2>/dev/null || echo "")"
-            referrers_note="- **Referrers:** copied (child manifests processed: ${child_count}${ref_count:+, image-level referrers: ${ref_count}})"
-          else
-            crane copy "${SOURCE_REF}" "${DEST_REF}"
-          fi
-
-          new_digest="$(crane digest "${DEST_REF}")"
-          echo "Copied. New destination digest: ${new_digest}"
-          {
-            echo "### Mirror image: copied :inbox_tray:"
-            echo ""
-            echo "- **Source:** \`${SOURCE_REF}\`"
-            echo "- **Destination:** \`${DEST_REF}\`"
-            echo "- **Previous digest:** \`${dest_digest:-<none>}\`"
-            echo "- **New digest:** \`${new_digest}\`"
-            # Use an `if` rather than `[ ... ] && echo`: the latter returns a
-            # non-zero status when referrers_note is empty, and as the final
-            # command in this step that would fail the job under `set -e`.
-            if [ -n "${referrers_note}" ]; then echo "${referrers_note}"; fi
-          } >> "${GITHUB_STEP_SUMMARY}"

--- a/.github/workflows/_scan-image.yml
+++ b/.github/workflows/_scan-image.yml
@@ -280,6 +280,14 @@ jobs:
           remaining_md="${REMAINING_MD:-}"
           excepted_md="${EXCEPTED_MD:-}"
 
+          # Map delete-image's raw status to user-facing wording for the report.
+          case "${DEL_STATUS:-}" in
+            deleted) del_msg="source deleted" ;;
+            skipped) del_msg="source kept (deletion skipped)" ;;
+            failed)  del_msg="source kept (delete failed)" ;;
+            *)       del_msg="source kept" ;;
+          esac
+
           case "${decision}" in
             blocked)
               result_class="blocked"; result="blocked"; icon=":no_entry:"
@@ -289,7 +297,7 @@ jobs:
               promoted_yesno="no (dry run)" ;;
             promote)
               result_class="promoted"
-              result="promoted (source ${DEL_STATUS:-kept})"
+              result="promoted (${del_msg})"
               icon=":white_check_mark:"
               promoted_yesno="yes → ${dest}" ;;
             *)

--- a/.github/workflows/_scan-image.yml
+++ b/.github/workflows/_scan-image.yml
@@ -4,14 +4,22 @@
 # not meant to be triggered directly. It is called by per-image "scan-*"
 # workflows via `uses:`.
 #
-# For every tag in `source_repo` it:
-#   1. scans the image with Trivy,
-#   2. applies a severity threshold plus an optional CVE exception list,
-#   3. promotes passing images into `dest_repo` with `crane copy`,
-#   4. attaches an empty OCI scan-report referrer with `oras attach`, and
-#   5. deletes the promoted tag from quarantine (when a delete token is set).
+# It orchestrates the shared composite actions under .github/actions/ and fans
+# the work out across a job matrix: an "enumerate" job lists the quarantine tags
+# (enumerate-tags) and a "scan" job runs once per tag, in parallel, performing
+# scan-image -> evaluate-findings -> mirror-image (promote) -> attach-scan-report
+# -> delete-image. A final "summary" job aggregates the per-tag results.
 #
-# See docs/architecture/workflows/scan-and-promote-workflows.md.
+# For every tag in `source_repo` it:
+#   1. scans the image with Trivy (scan-image),
+#   2. applies a severity threshold plus an optional CVE exception list
+#      (evaluate-findings),
+#   3. promotes passing images into `dest_repo` (mirror-image, force),
+#   4. attaches an OCI scan-report referrer (attach-scan-report), and
+#   5. deletes the promoted tag from quarantine (delete-image).
+#
+# Terminology and the action catalogue: see docs/reference/workflow-actions.md.
+# See also docs/architecture/workflows/scan-and-promote-workflows.md.
 name: _reusable / scan-image
 
 on:
@@ -56,35 +64,98 @@ on:
         required: false
 
 jobs:
+  # --- Phase 1: list the quarantine tags and resolve the severity set. --------
+  # Distinguishes an empty / not-yet-created repository (expected, has_tags
+  # false) from a real failure such as an auth or transient registry error.
+  enumerate:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: read
+    outputs:
+      tags-json: ${{ steps.enumerate.outputs.tags-json }}
+      has-tags: ${{ steps.enumerate.outputs.has-tags }}
+      severities: ${{ steps.config.outputs.severities }}
+    steps:
+      - name: Check out actions
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Set up crane
+        uses: imjasonh/setup-crane@31b88efe9de28ae0ffa220711af4b60be9435f6e # v0.4
+
+      - name: Log in to GHCR
+        uses: ./.github/actions/registry-login
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ github.token }}
+
+      - name: Resolve severity set
+        id: config
+        env:
+          THRESHOLD: "${{ inputs.severity_threshold }}"
+        run: |
+          set -euo pipefail
+          case "${THRESHOLD}" in
+            LOW)      severities="LOW,MEDIUM,HIGH,CRITICAL" ;;
+            MEDIUM)   severities="MEDIUM,HIGH,CRITICAL" ;;
+            HIGH)     severities="HIGH,CRITICAL" ;;
+            CRITICAL) severities="CRITICAL" ;;
+            *) echo "::error::Invalid severity_threshold '${THRESHOLD}' (expected LOW|MEDIUM|HIGH|CRITICAL)"; exit 1 ;;
+          esac
+          echo "severities=${severities}" >> "${GITHUB_OUTPUT}"
+
+      - name: Enumerate quarantine tags
+        id: enumerate
+        uses: ./.github/actions/enumerate-tags
+        with:
+          repository: ${{ inputs.source_repo }}
+
+      - name: Note empty repository
+        if: steps.enumerate.outputs.has-tags != 'true'
+        env:
+          SOURCE_REPO: "${{ inputs.source_repo }}"
+          DEST_REPO: "${{ inputs.dest_repo }}"
+        run: |
+          set -euo pipefail
+          {
+            echo "### Scan & promote: \`${SOURCE_REPO}\` → \`${DEST_REPO}\`"
+            echo ""
+            echo "No tags found in the source repository; nothing to do."
+          } >> "${GITHUB_STEP_SUMMARY}"
+
+  # --- Phase 2: scan, gate, promote, attest, and clean up — one job per tag. ---
   scan:
+    needs: enumerate
+    if: needs.enumerate.outputs.has-tags == 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: read
       packages: write
-    # Shared across every step in this job. Step-local state (the work dir, the
-    # resolved severity set, GHCR package coordinates) is computed in "Prepare"
-    # and exported via $GITHUB_ENV so later standalone steps can read it.
+    strategy:
+      fail-fast: false
+      matrix:
+        tag: ${{ fromJSON(needs.enumerate.outputs.tags-json) }}
     env:
       SOURCE_REPO: "${{ inputs.source_repo }}"
       DEST_REPO: "${{ inputs.dest_repo }}"
       THRESHOLD: "${{ inputs.severity_threshold }}"
-      EXCEPTIONS: "${{ inputs.cve_exceptions }}"
-      DELETE_SOURCE: "${{ inputs.delete_source }}"
+      SEVERITIES: "${{ needs.enumerate.outputs.severities }}"
+      TAG: "${{ matrix.tag }}"
       DRY_RUN: "${{ inputs.dry_run }}"
-      TRIVY_VERSION: "${{ inputs.trivy_version }}"
       # Authenticate Trivy's remote image pulls to GHCR.
       TRIVY_USERNAME: "${{ github.actor }}"
       TRIVY_PASSWORD: "${{ github.token }}"
     steps:
+      - name: Check out actions
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
       - name: Set up crane
         uses: imjasonh/setup-crane@31b88efe9de28ae0ffa220711af4b60be9435f6e # v0.4
 
       - name: Set up oras
         uses: oras-project/setup-oras@38de303aac69abb66f3e6255b7198bff35f323e3 # v2.0.0
         with:
-          # ORAS CLI version (independent of the setup-oras action version above).
-          # Must be a version known to the pinned setup-oras action; v2.0.0
-          # supports ORAS CLI up to 1.3.1.
           version: 1.3.1
 
       - name: Set up Trivy
@@ -93,162 +164,145 @@ jobs:
           version: ${{ inputs.trivy_version }}
 
       - name: Log in to GHCR
-        run: |
-          set -euo pipefail
-          echo "${{ github.token }}" | crane auth login ghcr.io \
-            --username "${{ github.actor }}" --password-stdin
-          echo "${{ github.token }}" | oras login ghcr.io \
-            --username "${{ github.actor }}" --password-stdin
+        uses: ./.github/actions/registry-login
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ github.token }}
+          with-oras: "true"
 
-      # --- Phase 1: resolve config, exceptions, and deletion coordinates. -----
-      # Exports the work dir, severity set, resolved Trivy version, and GHCR
-      # package coordinates via $GITHUB_ENV so the standalone steps below can
-      # consume them without recomputing.
-      - name: Prepare scan environment
+      # Normalise the exception list and resolve the actual Trivy version for the
+      # referrer annotation; both feed the per-tag actions below.
+      - name: Prepare gate inputs
+        id: prepare
         env:
-          DELETE_TOKEN: "${{ secrets.ghcr_delete_token }}"
+          EXCEPTIONS: "${{ inputs.cve_exceptions }}"
+          TRIVY_VERSION: "${{ inputs.trivy_version }}"
         run: |
           set -euo pipefail
           export LC_ALL=C
 
           work="${RUNNER_TEMP}/cssc-scan"
-          mkdir -p "${work}/state"
+          mkdir -p "${work}"
           echo "WORK=${work}" >> "${GITHUB_ENV}"
 
-          # --- Resolve the blocking severity set from the threshold floor. ------
-          case "${THRESHOLD}" in
-            LOW)      severities="LOW,MEDIUM,HIGH,CRITICAL" ;;
-            MEDIUM)   severities="MEDIUM,HIGH,CRITICAL" ;;
-            HIGH)     severities="HIGH,CRITICAL" ;;
-            CRITICAL) severities="CRITICAL" ;;
-            *) echo "::error::Invalid severity_threshold '${THRESHOLD}' (expected LOW|MEDIUM|HIGH|CRITICAL)"; exit 1 ;;
-          esac
-          echo "SEVERITIES=${severities}" >> "${GITHUB_ENV}"
-
-          # --- Normalise the exception list into a sorted, deduped file. --------
           exceptions_file="${work}/exceptions.txt"
           : > "${exceptions_file}"
           if [ -n "${EXCEPTIONS}" ]; then
             printf '%s\n' "${EXCEPTIONS}" | tr '|' '\n' | sed '/^[[:space:]]*$/d' \
               | tr -d '[:space:]' | sort -u > "${exceptions_file}"
           fi
+          echo "EXCEPTIONS_FILE=${exceptions_file}" >> "${GITHUB_ENV}"
+          echo "exceptions-file=${exceptions_file}" >> "${GITHUB_OUTPUT}"
 
-          # --- Resolve the actual Trivy version for the referrer annotation. ----
           trivy_resolved="$(trivy version -f json 2>/dev/null | jq -r '.Version // empty' || true)"
           [ -n "${trivy_resolved}" ] || trivy_resolved="${TRIVY_VERSION#v}"
           echo "TRIVY_RESOLVED=${trivy_resolved}" >> "${GITHUB_ENV}"
+          echo "trivy-resolved=${trivy_resolved}" >> "${GITHUB_OUTPUT}"
 
-          # --- Work out the GHCR package coordinates for deletion. --------------
-          owner="$(printf '%s' "${SOURCE_REPO}" | awk -F/ '{print $2}')"
-          pkg_path="$(printf '%s' "${SOURCE_REPO}" | cut -d/ -f3-)"
-          pkg_enc="$(printf '%s' "${pkg_path}" | sed 's:/:%2F:g')"
-          owner_type=""
-          if [ "${DELETE_SOURCE}" = "true" ] && [ -n "${DELETE_TOKEN}" ]; then
-            owner_type="$(GH_TOKEN="${DELETE_TOKEN}" gh api "users/${owner}" --jq '.type' 2>/dev/null || true)"
-          fi
-          {
-            echo "PKG_OWNER=${owner}"
-            echo "PKG_ENC=${pkg_enc}"
-            echo "OWNER_TYPE=${owner_type}"
-          } >> "${GITHUB_ENV}"
+      - name: Scan image
+        id: scan
+        uses: ./.github/actions/scan-image
+        with:
+          image-ref: ${{ inputs.source_repo }}:${{ matrix.tag }}
+          severities: ${{ needs.enumerate.outputs.severities }}
+          output-dir: ${{ runner.temp }}/cssc-scan/state
 
-      # --- Phase 2: list the quarantine tags. ---------------------------------
-      # Distinguish an empty / not-yet-created repository (expected, has_tags
-      # false) from a real failure such as an auth or transient registry error
-      # (must fail loudly rather than silently scanning nothing).
-      - name: Enumerate quarantine tags
-        id: enumerate
+      - name: Evaluate findings
+        id: evaluate
+        uses: ./.github/actions/evaluate-findings
+        with:
+          blocking-ids-file: ${{ steps.scan.outputs.blocking-ids-path }}
+          exceptions-file: ${{ steps.prepare.outputs.exceptions-file }}
+          dry-run: ${{ inputs.dry_run }}
+          output-dir: ${{ runner.temp }}/cssc-scan/state
+
+      - name: Promote passing image
+        id: promote
+        if: steps.evaluate.outputs.decision == 'promote'
+        uses: ./.github/actions/mirror-image
+        with:
+          source-image: ${{ inputs.source_repo }}
+          source-tag: ${{ matrix.tag }}
+          dest-image: ${{ inputs.dest_repo }}
+          dest-tag: ${{ matrix.tag }}
+          force: "true"
+
+      - name: Attach scan-report attestation
+        if: steps.evaluate.outputs.decision == 'promote'
+        uses: ./.github/actions/attach-scan-report
+        with:
+          image-ref: ${{ inputs.dest_repo }}:${{ matrix.tag }}
+          source-repo: ${{ inputs.source_repo }}
+          tag: ${{ matrix.tag }}
+          threshold: ${{ inputs.severity_threshold }}
+          excepted-str: ${{ steps.evaluate.outputs.excepted-str }}
+          scanner-version: ${{ steps.prepare.outputs.trivy-resolved }}
+          method: image
+
+      - name: Delete promoted tag from quarantine
+        id: delete
+        if: steps.evaluate.outputs.decision == 'promote' && inputs.delete_source
+        uses: ./.github/actions/delete-image
+        with:
+          repository: ${{ inputs.source_repo }}
+          tag: ${{ matrix.tag }}
+          token: ${{ secrets.ghcr_delete_token }}
+
+      # Render this tag's run log + result fragment and upload it for the summary
+      # job to aggregate. Runs even if an earlier step failed so partial results
+      # are still reported.
+      - name: Record result
+        if: always()
+        env:
+          DECISION: "${{ steps.evaluate.outputs.decision }}"
+          BLOCKING_COUNT: "${{ steps.evaluate.outputs.blocking-count }}"
+          REMAINING_COUNT: "${{ steps.evaluate.outputs.remaining-count }}"
+          EXCEPTED_COUNT: "${{ steps.evaluate.outputs.excepted-count }}"
+          REMAINING_MD: "${{ steps.evaluate.outputs.remaining-md }}"
+          EXCEPTED_MD: "${{ steps.evaluate.outputs.excepted-md }}"
+          REPORT_PATH: "${{ steps.scan.outputs.report-path }}"
+          DEL_STATUS: "${{ steps.delete.outputs.status }}"
         run: |
           set -euo pipefail
           export LC_ALL=C
 
-          ls_err="${WORK}/crane-ls.err"
-          if tags="$(crane ls "${SOURCE_REPO}" 2>"${ls_err}")"; then
-            :
-          else
-            if grep -qiE 'NAME_UNKNOWN|not found|MANIFEST_UNKNOWN|UNAUTHORIZED.*not found|repository name not known' "${ls_err}"; then
-              echo "Source repository ${SOURCE_REPO} has no tags yet; nothing to scan."
-              tags=""
-            else
-              echo "::error::Failed to list tags for ${SOURCE_REPO}:"
-              cat "${ls_err}" >&2
-              exit 1
-            fi
-          fi
+          safe="${TAG//[^A-Za-z0-9_.-]/_}"
+          out="${RUNNER_TEMP}/result/${safe}"
+          mkdir -p "${out}"
 
-          if [ -z "${tags}" ]; then
-            echo "No tags found in ${SOURCE_REPO}; nothing to scan."
-            {
-              echo "### Scan & promote: \`${SOURCE_REPO}\` → \`${DEST_REPO}\`"
-              echo ""
-              echo "No tags found in the source repository; nothing to do."
-            } >> "${GITHUB_STEP_SUMMARY}"
-            echo "has_tags=false" >> "${GITHUB_OUTPUT}"
-            exit 0
-          fi
+          src="${SOURCE_REPO}:${TAG}"
+          dest="${DEST_REPO}:${TAG}"
+          decision="${DECISION:-unknown}"
+          blocking_count="${BLOCKING_COUNT:-0}"
+          remaining_count="${REMAINING_COUNT:-0}"
+          excepted_count="${EXCEPTED_COUNT:-0}"
+          remaining_md="${REMAINING_MD:-}"
+          excepted_md="${EXCEPTED_MD:-}"
 
-          printf '%s\n' "${tags}" > "${WORK}/tags.txt"
-          echo "has_tags=true" >> "${GITHUB_OUTPUT}"
+          case "${decision}" in
+            blocked)
+              result_class="blocked"; result="blocked"; icon=":no_entry:"
+              promoted_yesno="no (left in quarantine)" ;;
+            dryrun)
+              result_class="promoted"; result="would promote"; icon=":mag:"
+              promoted_yesno="no (dry run)" ;;
+            promote)
+              result_class="promoted"
+              result="promoted (source ${DEL_STATUS:-kept})"
+              icon=":white_check_mark:"
+              promoted_yesno="yes → ${dest}" ;;
+            *)
+              result_class="unknown"; result="unknown (scan failed?)"; icon=":grey_question:"
+              promoted_yesno="—" ;;
+          esac
+          printf '%s' "${result_class}" > "${out}/result_class"
+          printf '%s' "${TRIVY_RESOLVED:-}" > "${out}/scanner"
 
-      # --- Phase 3: scan each tag with Trivy. ---------------------------------
-      # Per-tag state lives under ${WORK}/state/<safe>/ so later steps can pick
-      # up where this one left off.
-      - name: Scan images with Trivy
-        if: steps.enumerate.outputs.has_tags == 'true'
-        run: |
-          set -euo pipefail
-          export LC_ALL=C
-
-          while IFS= read -r tag; do
-            [ -n "${tag}" ] || continue
-            src="${SOURCE_REPO}:${tag}"
-            safe="${tag//[^A-Za-z0-9_.-]/_}"
-            state="${WORK}/state/${safe}"
-            mkdir -p "${state}"
-            printf '%s' "${tag}" > "${state}/tag"
-
-            echo "::group::Scanning ${src}"
-            trivy image --quiet --scanners vuln --severity "${SEVERITIES}" \
-              --format json --output "${state}/report.json" "${src}"
-            echo "::endgroup::"
-          done < "${WORK}/tags.txt"
-
-      # --- Phase 4: apply the threshold + exception gate. ---------------------
-      # Records per-tag counts and a decision (blocked | dryrun | promote) that
-      # the promote/attest/cleanup steps act on. Does not itself fail the job on
-      # a blocked image — blocked tags are simply left in quarantine.
-      - name: Gate on scan findings
-        if: steps.enumerate.outputs.has_tags == 'true'
-        run: |
-          set -euo pipefail
-          export LC_ALL=C
-
-          exceptions_file="${WORK}/exceptions.txt"
-          for state in "${WORK}"/state/*/; do
-            [ -d "${state}" ] || continue
-            tag="$(cat "${state}/tag")"
-            report="${state}/report.json"
-
-            jq -r '[.Results[]?.Vulnerabilities[]?.VulnerabilityID] | unique | .[]' \
-              "${report}" | sort -u > "${state}/blocking.txt"
-            comm -23 "${state}/blocking.txt" "${exceptions_file}" > "${state}/remaining.txt"
-            comm -12 "${state}/blocking.txt" "${exceptions_file}" > "${state}/excepted.txt"
-
-            blocking_count="$(wc -l < "${state}/blocking.txt" | tr -d ' ')"
-            remaining_count="$(wc -l < "${state}/remaining.txt" | tr -d ' ')"
-            excepted_count="$(wc -l < "${state}/excepted.txt" | tr -d ' ')"
-            printf '%s' "${blocking_count}" > "${state}/blocking_count"
-            printf '%s' "${remaining_count}" > "${state}/remaining_count"
-            printf '%s' "${excepted_count}" > "${state}/excepted_count"
-
-            # Pipe-separated form is used only for the oras annotation.
-            paste -sd '|' "${state}/excepted.txt" > "${state}/excepted_str"
-            # Comma-separated, Markdown-safe display forms for the summary tables
-            # (CVE IDs contain no '|', so a comma join keeps table columns intact).
-            paste -sd ',' "${state}/remaining.txt" | sed 's/,/, /g' > "${state}/remaining_md"
-            paste -sd ',' "${state}/excepted.txt" | sed 's/,/, /g' > "${state}/excepted_md"
-
-            # Per-CVE detail: id, severity, package, installed, fixed (deduped, ranked).
+          # Per-CVE detail (id, severity, package, installed, fixed) from the report.
+          vulns_tsv="${out}/vulns.tsv"
+          : > "${vulns_tsv}"
+          if [ -n "${REPORT_PATH}" ] && [ -s "${REPORT_PATH}" ]; then
             jq -r '
               [ .Results[]? | (.Vulnerabilities[]? | {
                   id: .VulnerabilityID,
@@ -261,216 +315,120 @@ jobs:
               | map(. + {rank: ({"CRITICAL":0,"HIGH":1,"MEDIUM":2,"LOW":3}[.sev] // 9)})
               | sort_by(.rank, .id)
               | .[] | [.id, .sev, .pkg, .installed, .fixed] | @tsv
-            ' "${report}" > "${state}/vulns.tsv"
+            ' "${REPORT_PATH}" > "${vulns_tsv}" || true
+          fi
 
-            if [ "${remaining_count}" -gt 0 ]; then
-              echo "blocked" > "${state}/decision"
-            elif [ "${DRY_RUN}" = "true" ]; then
-              echo "dryrun" > "${state}/decision"
+          # --- Human-readable report to the run log. ---------------------------
+          {
+            echo "================================================================"
+            echo "Image:            ${src}"
+            echo "Result:           ${result}"
+            echo "Promoted:         ${promoted_yesno}"
+            echo "Threshold:        ${THRESHOLD} (severities: ${SEVERITIES})"
+            echo "CVEs ≥ ${THRESHOLD}:   ${blocking_count} (blocking: ${remaining_count}, excepted: ${excepted_count})"
+            if [ -s "${vulns_tsv}" ]; then
+              printf '  %-22s %-9s %-28s %-18s %s\n' "CVE" "SEVERITY" "PACKAGE" "INSTALLED" "STATUS"
+              while IFS="$(printf '\t')" read -r id sev pkg installed fixed; do
+                if [ -s "${EXCEPTIONS_FILE}" ] && grep -qxF "${id}" "${EXCEPTIONS_FILE}"; then st="EXCEPTED"; else st="BLOCKING"; fi
+                printf '  %-22s %-9s %-28s %-18s %s\n' "${id}" "${sev}" "${pkg}" "${installed:-—}" "${st}"
+              done < "${vulns_tsv}"
             else
-              echo "promote" > "${state}/decision"
+              echo "  (no vulnerabilities at or above the threshold)"
             fi
-            echo "Gate ${SOURCE_REPO}:${tag} -> $(cat "${state}/decision") (blocking ${remaining_count}, excepted ${excepted_count})"
-          done
-
-      # --- Phase 5: promote passing images. -----------------------------------
-      # Skipped entirely on a dry run. Only tags whose gate decision is
-      # "promote" are copied; a "promoted" marker drives the later steps.
-      - name: Promote passing images
-        if: steps.enumerate.outputs.has_tags == 'true' && !inputs.dry_run
-        run: |
-          set -euo pipefail
-          export LC_ALL=C
-
-          for state in "${WORK}"/state/*/; do
-            [ -d "${state}" ] || continue
-            [ "$(cat "${state}/decision")" = "promote" ] || continue
-            tag="$(cat "${state}/tag")"
-            src="${SOURCE_REPO}:${tag}"
-            dest="${DEST_REPO}:${tag}"
-            echo "Promoting ${src} -> ${dest}"
-            crane copy "${src}" "${dest}"
-            printf '%s' "${dest}" > "${state}/promoted"
-          done
-
-      # --- Phase 6: attach the scan-report referrer to promoted images. -------
-      - name: Attach scan-report attestation
-        if: steps.enumerate.outputs.has_tags == 'true' && !inputs.dry_run
-        run: |
-          set -euo pipefail
-          export LC_ALL=C
-
-          for state in "${WORK}"/state/*/; do
-            [ -d "${state}" ] || continue
-            [ -f "${state}/promoted" ] || continue
-            tag="$(cat "${state}/tag")"
-            dest="$(cat "${state}/promoted")"
-            excepted_str="$(cat "${state}/excepted_str")"
-            created="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
-            echo "Attaching scan report to ${dest}"
-            oras attach --artifact-type application/vnd.cssc.scan-report.v1+json \
-              --annotation "org.opencontainers.image.created=${created}" \
-              --annotation "com.cssc.scan.source=${SOURCE_REPO}" \
-              --annotation "com.cssc.scan.tag=${tag}" \
-              --annotation "com.cssc.scan.threshold=${THRESHOLD}" \
-              --annotation "com.cssc.scan.exceptions=${excepted_str}" \
-              --annotation "com.cssc.scan.scanner=trivy" \
-              --annotation "com.cssc.scan.scanner-version=${TRIVY_RESOLVED}" \
-              "${dest}"
-          done
-
-      # --- Phase 7: delete promoted tags from quarantine. ---------------------
-      - name: Delete promoted tags from quarantine
-        if: steps.enumerate.outputs.has_tags == 'true' && !inputs.dry_run && inputs.delete_source
-        env:
-          DELETE_TOKEN: "${{ secrets.ghcr_delete_token }}"
-        run: |
-          set -euo pipefail
-          export LC_ALL=C
-
-          delete_quarantine_tag() {
-            local tag="$1" base vid
-            if [ "${OWNER_TYPE}" = "Organization" ]; then
-              base="orgs/${PKG_OWNER}/packages/container/${PKG_ENC}"
-            else
-              base="user/packages/container/${PKG_ENC}"
-            fi
-            vid="$(GH_TOKEN="${DELETE_TOKEN}" gh api --paginate "${base}/versions" \
-                   --jq ".[] | select(.metadata.container.tags[]? == \"${tag}\") | .id" 2>/dev/null \
-                   | head -n1 || true)"
-            if [ -z "${vid}" ]; then
-              echo "::warning::Could not resolve a package version id for tag '${tag}'; skipping deletion."
-              return 1
-            fi
-            GH_TOKEN="${DELETE_TOKEN}" gh api -X DELETE "${base}/versions/${vid}" >/dev/null
           }
 
-          for state in "${WORK}"/state/*/; do
-            [ -d "${state}" ] || continue
-            [ -f "${state}/promoted" ] || continue
-            tag="$(cat "${state}/tag")"
-            if [ -z "${DELETE_TOKEN}" ]; then
-              echo "::warning::delete_source=true but no ghcr_delete_token provided; skipping deletion of ${SOURCE_REPO}:${tag}."
-              printf '%s' "skipped (no token)" > "${state}/del_status"
-            elif delete_quarantine_tag "${tag}"; then
-              printf '%s' "deleted" > "${state}/del_status"
-            else
-              printf '%s' "delete failed" > "${state}/del_status"
-            fi
-          done
+          # --- Summary table row. ----------------------------------------------
+          printf '| `%s` | %s %s | %s | %s | %s |\n' \
+            "${TAG}" "${icon}" "${result}" "${blocking_count}" \
+            "${remaining_md:-—}" "${excepted_md:-—}" > "${out}/row.md"
 
-      # --- Phase 8: render the run log and job summary. -----------------------
-      # Runs even if an earlier phase failed (as long as tags were enumerated)
-      # so partial results are still reported.
+          # --- Collapsible per-image detail for the job summary. ----------------
+          {
+            echo ""
+            echo "<details><summary><code>${TAG}</code> — ${icon} ${result} · ${blocking_count} CVE(s) ≥ ${THRESHOLD}</summary>"
+            echo ""
+            echo "- **Source:** \`${src}\`"
+            echo "- **Destination:** \`${dest}\`"
+            echo "- **Promoted:** ${promoted_yesno}"
+            echo "- **Blocking (not excepted):** ${remaining_count} · **Excepted:** ${excepted_count}"
+            echo ""
+            echo "| CVE | Severity | Package | Installed | Fixed | Status |"
+            echo "| --- | --- | --- | --- | --- | --- |"
+            if [ -s "${vulns_tsv}" ]; then
+              while IFS="$(printf '\t')" read -r id sev pkg installed fixed; do
+                if [ -s "${EXCEPTIONS_FILE}" ] && grep -qxF "${id}" "${EXCEPTIONS_FILE}"; then
+                  st=":large_yellow_circle: excepted"
+                else
+                  st=":red_circle: blocking"
+                fi
+                printf '| %s | %s | `%s` | %s | %s | %s |\n' \
+                  "${id}" "${sev}" "${pkg}" "${installed:-—}" "${fixed:-—}" "${st}"
+              done < "${vulns_tsv}"
+            else
+              echo "| — | — | — | — | — | none ≥ ${THRESHOLD} |"
+            fi
+            echo ""
+            echo "</details>"
+          } > "${out}/detail.md"
+
+      - name: Upload result
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: scan-result-${{ strategy.job-index }}
+          path: ${{ runner.temp }}/result
+          retention-days: 1
+
+  # --- Phase 3: aggregate the per-tag results into one job summary. -----------
+  summary:
+    needs: [enumerate, scan]
+    if: always() && needs.enumerate.outputs.has-tags == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download results
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          pattern: scan-result-*
+          path: ${{ runner.temp }}/results
+          merge-multiple: true
+
       - name: Write job summary
-        if: always() && steps.enumerate.outputs.has_tags == 'true'
+        env:
+          SOURCE_REPO: "${{ inputs.source_repo }}"
+          DEST_REPO: "${{ inputs.dest_repo }}"
+          THRESHOLD: "${{ inputs.severity_threshold }}"
+          SEVERITIES: "${{ needs.enumerate.outputs.severities }}"
+          DRY_RUN: "${{ inputs.dry_run }}"
         run: |
           set -euo pipefail
           export LC_ALL=C
 
-          exceptions_file="${WORK}/exceptions.txt"
+          results="${RUNNER_TEMP}/results"
           promoted=0
           blocked=0
-          rows="${WORK}/rows.md"
-          details_md="${WORK}/details.md"
+          rows="${RUNNER_TEMP}/rows.md"
+          details_md="${RUNNER_TEMP}/details.md"
           : > "${rows}"
           : > "${details_md}"
 
-          for state in "${WORK}"/state/*/; do
-            [ -d "${state}" ] || continue
-            tag="$(cat "${state}/tag")"
-            src="${SOURCE_REPO}:${tag}"
-            dest="${DEST_REPO}:${tag}"
-            decision="$(cat "${state}/decision" 2>/dev/null || echo "")"
-            blocking_count="$(cat "${state}/blocking_count" 2>/dev/null || echo 0)"
-            remaining_count="$(cat "${state}/remaining_count" 2>/dev/null || echo 0)"
-            excepted_count="$(cat "${state}/excepted_count" 2>/dev/null || echo 0)"
-            remaining_md="$(cat "${state}/remaining_md" 2>/dev/null || true)"
-            excepted_md="$(cat "${state}/excepted_md" 2>/dev/null || true)"
-            vulns_tsv="${state}/vulns.tsv"
-
-            case "${decision}" in
-              blocked)
-                blocked=$((blocked + 1))
-                result="blocked"
-                icon=":no_entry:"
-                promoted_yesno="no (left in quarantine)" ;;
-              dryrun)
-                promoted=$((promoted + 1))
-                result="would promote"
-                icon=":mag:"
-                promoted_yesno="no (dry run)" ;;
-              promote)
-                promoted=$((promoted + 1))
-                del_status="$(cat "${state}/del_status" 2>/dev/null || echo "kept")"
-                result="promoted (source ${del_status})"
-                icon=":white_check_mark:"
-                promoted_yesno="yes → ${dest}" ;;
-              *)
-                result="unknown"
-                icon=":grey_question:"
-                promoted_yesno="—" ;;
+          scanner=""
+          for d in "${results}"/*/; do
+            [ -d "${d}" ] || continue
+            [ -f "${d}/row.md" ] || continue
+            cat "${d}/row.md" >> "${rows}"
+            [ -f "${d}/detail.md" ] && cat "${d}/detail.md" >> "${details_md}"
+            [ -z "${scanner}" ] && [ -f "${d}/scanner" ] && scanner="$(cat "${d}/scanner")"
+            case "$(cat "${d}/result_class" 2>/dev/null || echo unknown)" in
+              promoted) promoted=$((promoted + 1)) ;;
+              blocked)  blocked=$((blocked + 1)) ;;
             esac
-
-            # --- Human-readable report to the run log. ---------------------------
-            {
-              echo "================================================================"
-              echo "Image:            ${src}"
-              echo "Result:           ${result}"
-              echo "Promoted:         ${promoted_yesno}"
-              echo "Threshold:        ${THRESHOLD} (severities: ${SEVERITIES})"
-              echo "CVEs ≥ ${THRESHOLD}:   ${blocking_count} (blocking: ${remaining_count}, excepted: ${excepted_count})"
-              if [ -s "${vulns_tsv}" ]; then
-                printf '  %-22s %-9s %-28s %-18s %s\n' "CVE" "SEVERITY" "PACKAGE" "INSTALLED" "STATUS"
-                while IFS="$(printf '\t')" read -r id sev pkg installed fixed; do
-                  if grep -qxF "${id}" "${exceptions_file}"; then st="EXCEPTED"; else st="BLOCKING"; fi
-                  printf '  %-22s %-9s %-28s %-18s %s\n' "${id}" "${sev}" "${pkg}" "${installed:-—}" "${st}"
-                done < "${vulns_tsv}"
-              else
-                echo "  (no vulnerabilities at or above the threshold)"
-              fi
-            }
-
-            # --- Summary table row. ----------------------------------------------
-            printf '| `%s` | %s %s | %s | %s | %s |\n' \
-              "${tag}" "${icon}" "${result}" "${blocking_count}" \
-              "${remaining_md:-—}" "${excepted_md:-—}" >> "${rows}"
-
-            # --- Collapsible per-image detail for the job summary. ----------------
-            {
-              echo ""
-              echo "<details><summary><code>${tag}</code> — ${icon} ${result} · ${blocking_count} CVE(s) ≥ ${THRESHOLD}</summary>"
-              echo ""
-              echo "- **Source:** \`${src}\`"
-              echo "- **Destination:** \`${dest}\`"
-              echo "- **Promoted:** ${promoted_yesno}"
-              echo "- **Blocking (not excepted):** ${remaining_count} · **Excepted:** ${excepted_count}"
-              echo ""
-              echo "| CVE | Severity | Package | Installed | Fixed | Status |"
-              echo "| --- | --- | --- | --- | --- | --- |"
-              if [ -s "${vulns_tsv}" ]; then
-                while IFS="$(printf '\t')" read -r id sev pkg installed fixed; do
-                  if grep -qxF "${id}" "${exceptions_file}"; then
-                    st=":large_yellow_circle: excepted"
-                  else
-                    st=":red_circle: blocking"
-                  fi
-                  printf '| %s | %s | `%s` | %s | %s | %s |\n' \
-                    "${id}" "${sev}" "${pkg}" "${installed:-—}" "${fixed:-—}" "${st}"
-                done < "${vulns_tsv}"
-              else
-                echo "| — | — | — | — | — | none ≥ ${THRESHOLD} |"
-              fi
-              echo ""
-              echo "</details>"
-            } >> "${details_md}"
           done
 
           {
             echo "### Scan & promote: \`${SOURCE_REPO}\` → \`${DEST_REPO}\`"
             echo ""
             echo "- **Threshold:** \`${THRESHOLD}\` (severities scanned: \`${SEVERITIES}\`)"
-            echo "- **Scanner:** trivy \`${TRIVY_RESOLVED}\`"
+            if [ -n "${scanner}" ]; then echo "- **Scanner:** trivy \`${scanner}\`"; fi
             echo "- **Dry run:** \`${DRY_RUN}\`"
             echo "- **Promoted:** ${promoted} · **Blocked:** ${blocked}"
             echo ""

--- a/.github/workflows/_scan-sbom-image.yml
+++ b/.github/workflows/_scan-sbom-image.yml
@@ -287,6 +287,14 @@ jobs:
           platform_count="${PLATFORM_COUNT:-0}"
           missing_sbom="${MISSING_SBOM:-0}"
 
+          # Map delete-image's raw status to user-facing wording for the report.
+          case "${DEL_STATUS:-}" in
+            deleted) del_msg="source deleted" ;;
+            skipped) del_msg="source kept (deletion skipped)" ;;
+            failed)  del_msg="source kept (delete failed)" ;;
+            *)       del_msg="source kept" ;;
+          esac
+
           case "${decision}" in
             blocked-missing-sbom)
               result_class="blocked"; result="blocked (missing SBOM)"; icon=":no_entry:"
@@ -299,7 +307,7 @@ jobs:
               promoted_yesno="no (dry run)" ;;
             promote)
               result_class="promoted"
-              result="promoted (source ${DEL_STATUS:-kept})"
+              result="promoted (${del_msg})"
               icon=":white_check_mark:"
               promoted_yesno="yes → ${dest}" ;;
             *)

--- a/.github/workflows/_scan-sbom-image.yml
+++ b/.github/workflows/_scan-sbom-image.yml
@@ -8,22 +8,17 @@
 # Unlike _scan-image.yml (which runs `trivy image` against the image filesystem),
 # this workflow is built for distroless / hardened images such as Docker
 # Hardened Images (DHI), which contain no package-manager metadata. Instead it
-# scans the **SBOM attestation** that the mirror copied alongside the image.
+# scans the SBOM attestation that the mirror copied alongside the image.
 #
-# For every image tag in `source_repo` it:
-#   1. enumerates the platforms in the image index,
-#   2. for each platform, locates the SBOM referrer (an in-toto attestation whose
-#      `in-toto.io/predicate-type` annotation matches `sbom_predicate_type`),
-#      pulls it from GHCR, and extracts the embedded SBOM predicate,
-#   3. scans each platform SBOM with `trivy sbom`,
-#   4. applies a severity threshold plus an optional CVE exception list across
-#      ALL platforms (blocks if any platform fails),
-#   5. promotes passing images into `dest_repo` with `oras cp -r` (carrying the
-#      image and all its referrers — SBOMs, provenance, VEX, signatures),
-#   6. attaches an empty OCI scan-report referrer with `oras attach`, and
-#   7. deletes the promoted tag from quarantine (when a delete token is set).
+# It orchestrates the shared composite actions under .github/actions/ and fans
+# the work out across a job matrix: an "enumerate" job lists the quarantine image
+# tags (enumerate-tags) and a "scan" job runs once per tag, in parallel,
+# performing scan-sbom -> evaluate-findings -> mirror-image (promote, with
+# referrers) -> attach-scan-report -> delete-image. A final "summary" job
+# aggregates the per-tag results.
 #
-# See docs/architecture/workflows/scan-and-promote-workflows.md.
+# Terminology and the action catalogue: see docs/reference/workflow-actions.md.
+# See also docs/architecture/workflows/scan-and-promote-workflows.md.
 name: _reusable / scan-sbom-image
 
 on:
@@ -73,24 +68,91 @@ on:
         required: false
 
 jobs:
+  # --- Phase 1: list the quarantine image tags and resolve the severity set. ---
+  # Drops sha256-* referrer fallback tags. Distinguishes an empty repository
+  # (expected, has_tags false) from a real failure.
+  enumerate:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: read
+    outputs:
+      tags-json: ${{ steps.enumerate.outputs.tags-json }}
+      has-tags: ${{ steps.enumerate.outputs.has-tags }}
+      severities: ${{ steps.config.outputs.severities }}
+    steps:
+      - name: Check out actions
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Set up crane
+        uses: imjasonh/setup-crane@31b88efe9de28ae0ffa220711af4b60be9435f6e # v0.4
+
+      - name: Log in to GHCR
+        uses: ./.github/actions/registry-login
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ github.token }}
+
+      - name: Resolve severity set
+        id: config
+        env:
+          THRESHOLD: "${{ inputs.severity_threshold }}"
+        run: |
+          set -euo pipefail
+          case "${THRESHOLD}" in
+            LOW)      severities="LOW,MEDIUM,HIGH,CRITICAL" ;;
+            MEDIUM)   severities="MEDIUM,HIGH,CRITICAL" ;;
+            HIGH)     severities="HIGH,CRITICAL" ;;
+            CRITICAL) severities="CRITICAL" ;;
+            *) echo "::error::Invalid severity_threshold '${THRESHOLD}' (expected LOW|MEDIUM|HIGH|CRITICAL)"; exit 1 ;;
+          esac
+          echo "severities=${severities}" >> "${GITHUB_OUTPUT}"
+
+      - name: Enumerate quarantine image tags
+        id: enumerate
+        uses: ./.github/actions/enumerate-tags
+        with:
+          repository: ${{ inputs.source_repo }}
+          exclude-referrer-tags: "true"
+
+      - name: Note empty repository
+        if: steps.enumerate.outputs.has-tags != 'true'
+        env:
+          SOURCE_REPO: "${{ inputs.source_repo }}"
+          DEST_REPO: "${{ inputs.dest_repo }}"
+        run: |
+          set -euo pipefail
+          {
+            echo "### SBOM scan & promote: \`${SOURCE_REPO}\` → \`${DEST_REPO}\`"
+            echo ""
+            echo "No image tags found in the source repository; nothing to do."
+          } >> "${GITHUB_STEP_SUMMARY}"
+
+  # --- Phase 2: scan SBOMs, gate, promote, attest, and clean up — per tag. -----
   scan:
+    needs: enumerate
+    if: needs.enumerate.outputs.has-tags == 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: read
       packages: write
-    # Shared across every step in this job. Step-local state (the work dir, the
-    # resolved severity set, GHCR package coordinates) is computed in "Prepare"
-    # and exported via $GITHUB_ENV so later standalone steps can read it.
+    strategy:
+      fail-fast: false
+      matrix:
+        tag: ${{ fromJSON(needs.enumerate.outputs.tags-json) }}
     env:
       SOURCE_REPO: "${{ inputs.source_repo }}"
       DEST_REPO: "${{ inputs.dest_repo }}"
       THRESHOLD: "${{ inputs.severity_threshold }}"
-      EXCEPTIONS: "${{ inputs.cve_exceptions }}"
+      SEVERITIES: "${{ needs.enumerate.outputs.severities }}"
       SBOM_PREDICATE_TYPE: "${{ inputs.sbom_predicate_type }}"
-      DELETE_SOURCE: "${{ inputs.delete_source }}"
+      TAG: "${{ matrix.tag }}"
       DRY_RUN: "${{ inputs.dry_run }}"
-      TRIVY_VERSION: "${{ inputs.trivy_version }}"
     steps:
+      - name: Check out actions
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
       - name: Set up crane
         uses: imjasonh/setup-crane@31b88efe9de28ae0ffa220711af4b60be9435f6e # v0.4
 
@@ -105,482 +167,239 @@ jobs:
           version: ${{ inputs.trivy_version }}
 
       - name: Log in to GHCR
-        run: |
-          set -euo pipefail
-          echo "${{ github.token }}" | crane auth login ghcr.io \
-            --username "${{ github.actor }}" --password-stdin
-          echo "${{ github.token }}" | oras login ghcr.io \
-            --username "${{ github.actor }}" --password-stdin
+        uses: ./.github/actions/registry-login
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ github.token }}
+          with-oras: "true"
 
-      # --- Phase 1: resolve config, exceptions, and deletion coordinates. -----
-      # Exports the work dir, severity set, resolved Trivy version, and GHCR
-      # package coordinates via $GITHUB_ENV so the standalone steps below can
-      # consume them without recomputing.
-      - name: Prepare scan environment
+      - name: Prepare gate inputs
+        id: prepare
         env:
-          DELETE_TOKEN: "${{ secrets.ghcr_delete_token }}"
+          EXCEPTIONS: "${{ inputs.cve_exceptions }}"
+          TRIVY_VERSION: "${{ inputs.trivy_version }}"
         run: |
           set -euo pipefail
           export LC_ALL=C
 
           work="${RUNNER_TEMP}/cssc-scan"
-          mkdir -p "${work}/state"
+          mkdir -p "${work}"
           echo "WORK=${work}" >> "${GITHUB_ENV}"
 
-          # --- Resolve the blocking severity set from the threshold floor. ------
-          case "${THRESHOLD}" in
-            LOW)      severities="LOW,MEDIUM,HIGH,CRITICAL" ;;
-            MEDIUM)   severities="MEDIUM,HIGH,CRITICAL" ;;
-            HIGH)     severities="HIGH,CRITICAL" ;;
-            CRITICAL) severities="CRITICAL" ;;
-            *) echo "::error::Invalid severity_threshold '${THRESHOLD}' (expected LOW|MEDIUM|HIGH|CRITICAL)"; exit 1 ;;
-          esac
-          echo "SEVERITIES=${severities}" >> "${GITHUB_ENV}"
-
-          # --- Normalise the exception list into a sorted, deduped file. --------
           exceptions_file="${work}/exceptions.txt"
           : > "${exceptions_file}"
           if [ -n "${EXCEPTIONS}" ]; then
             printf '%s\n' "${EXCEPTIONS}" | tr '|' '\n' | sed '/^[[:space:]]*$/d' \
               | tr -d '[:space:]' | sort -u > "${exceptions_file}"
           fi
+          echo "exceptions-file=${exceptions_file}" >> "${GITHUB_OUTPUT}"
 
-          # --- Resolve the actual Trivy version for the referrer annotation. ----
           trivy_resolved="$(trivy version -f json 2>/dev/null | jq -r '.Version // empty' || true)"
           [ -n "${trivy_resolved}" ] || trivy_resolved="${TRIVY_VERSION#v}"
           echo "TRIVY_RESOLVED=${trivy_resolved}" >> "${GITHUB_ENV}"
+          echo "trivy-resolved=${trivy_resolved}" >> "${GITHUB_OUTPUT}"
 
-          # --- Work out the GHCR package coordinates for deletion. --------------
-          owner="$(printf '%s' "${SOURCE_REPO}" | awk -F/ '{print $2}')"
-          pkg_path="$(printf '%s' "${SOURCE_REPO}" | cut -d/ -f3-)"
-          pkg_enc="$(printf '%s' "${pkg_path}" | sed 's:/:%2F:g')"
-          owner_type=""
-          if [ "${DELETE_SOURCE}" = "true" ] && [ -n "${DELETE_TOKEN}" ]; then
-            owner_type="$(GH_TOKEN="${DELETE_TOKEN}" gh api "users/${owner}" --jq '.type' 2>/dev/null || true)"
-          fi
-          {
-            echo "PKG_OWNER=${owner}"
-            echo "PKG_ENC=${pkg_enc}"
-            echo "OWNER_TYPE=${owner_type}"
-          } >> "${GITHUB_ENV}"
+      - name: Scan SBOMs
+        id: scan
+        uses: ./.github/actions/scan-sbom
+        with:
+          image-ref: ${{ inputs.source_repo }}:${{ matrix.tag }}
+          repository: ${{ inputs.source_repo }}
+          severities: ${{ needs.enumerate.outputs.severities }}
+          sbom-predicate-type: ${{ inputs.sbom_predicate_type }}
+          exceptions-file: ${{ steps.prepare.outputs.exceptions-file }}
+          output-dir: ${{ runner.temp }}/cssc-scan/state
 
-      # --- Phase 2: list the quarantine image tags (skip referrer fallbacks). --
-      # Distinguish an empty / not-yet-created repository (expected, has_tags
-      # false) from a real failure such as an auth or transient registry error.
-      - name: Enumerate quarantine tags
-        id: enumerate
-        run: |
-          set -euo pipefail
-          export LC_ALL=C
+      - name: Evaluate findings
+        id: evaluate
+        uses: ./.github/actions/evaluate-findings
+        with:
+          blocking-ids-file: ${{ steps.scan.outputs.blocking-ids-path }}
+          exceptions-file: ${{ steps.prepare.outputs.exceptions-file }}
+          dry-run: ${{ inputs.dry_run }}
+          missing-sbom-count: ${{ steps.scan.outputs.missing-sbom-count }}
+          output-dir: ${{ runner.temp }}/cssc-scan/state
 
-          ls_err="${WORK}/crane-ls.err"
-          if all_tags="$(crane ls "${SOURCE_REPO}" 2>"${ls_err}")"; then
-            :
-          else
-            if grep -qiE 'NAME_UNKNOWN|not found|MANIFEST_UNKNOWN|UNAUTHORIZED.*not found|repository name not known' "${ls_err}"; then
-              echo "Source repository ${SOURCE_REPO} has no tags yet; nothing to scan."
-              all_tags=""
-            else
-              echo "::error::Failed to list tags for ${SOURCE_REPO}:"
-              cat "${ls_err}" >&2
-              exit 1
-            fi
-          fi
+      - name: Promote passing image
+        id: promote
+        if: steps.evaluate.outputs.decision == 'promote'
+        uses: ./.github/actions/mirror-image
+        with:
+          source-image: ${{ inputs.source_repo }}
+          source-tag: ${{ matrix.tag }}
+          dest-image: ${{ inputs.dest_repo }}
+          dest-tag: ${{ matrix.tag }}
+          force: "true"
+          copy-referrers: "true"
 
-          tags="$(printf '%s\n' "${all_tags}" | grep -vE '^sha256-' || true)"
-          if [ -z "${tags}" ]; then
-            echo "No image tags found in ${SOURCE_REPO}; nothing to scan."
-            {
-              echo "### SBOM scan & promote: \`${SOURCE_REPO}\` → \`${DEST_REPO}\`"
-              echo ""
-              echo "No image tags found in the source repository; nothing to do."
-            } >> "${GITHUB_STEP_SUMMARY}"
-            echo "has_tags=false" >> "${GITHUB_OUTPUT}"
-            exit 0
-          fi
-
-          printf '%s\n' "${tags}" > "${WORK}/tags.txt"
-          echo "has_tags=true" >> "${GITHUB_OUTPUT}"
-
-      # --- Phase 3: extract and scan the per-platform SBOMs. ------------------
-      # For each tag, enumerate the platforms in the image index, locate each
-      # platform's SBOM referrer (an in-toto attestation whose predicate type
-      # matches sbom_predicate_type), extract the BOM, and scan it with
-      # `trivy sbom`. Per-tag state lives under ${WORK}/state/<safe>/.
-      - name: Scan platform SBOMs with Trivy
-        if: steps.enumerate.outputs.has_tags == 'true'
-        run: |
-          set -euo pipefail
-          export LC_ALL=C
-
-          # --- Extract the SBOM predicate for one platform manifest. ------------
-          # Echoes the path to a written SBOM file on success; returns non-zero
-          # when no SBOM referrer of the requested predicate type is found.
-          extract_platform_sbom() {
-            local plat_digest="$1" out="$2" ref_digest layer_digest stmt
-            ref_digest="$(oras discover --format json "${SOURCE_REPO}@${plat_digest}" 2>/dev/null \
-              | jq -r --arg PT "${SBOM_PREDICATE_TYPE}" '
-                  [.. | objects | select(.artifactType? == "application/vnd.in-toto+json")]
-                  | map(select(.annotations["in-toto.io/predicate-type"] == $PT))
-                  | .[0].digest // empty')"
-            [ -n "${ref_digest}" ] || return 1
-            layer_digest="$(oras manifest fetch "${SOURCE_REPO}@${ref_digest}" \
-              | jq -r '.layers[0].digest // empty')"
-            [ -n "${layer_digest}" ] || return 1
-            stmt="${WORK}/stmt.json"
-            oras blob fetch --output "${stmt}" "${SOURCE_REPO}@${layer_digest}"
-            # The blob is an in-toto Statement (DHI) or a DSSE envelope wrapping
-            # one. Extract the `.predicate` (the actual CycloneDX/SPDX BOM).
-            if jq -e '.payload and .payloadType' "${stmt}" >/dev/null 2>&1; then
-              jq -r '.payload' "${stmt}" | base64 -d | jq '.predicate' > "${out}"
-            else
-              jq '.predicate' "${stmt}" > "${out}"
-            fi
-            [ -s "${out}" ] || return 1
-            return 0
-          }
-
-          exceptions_file="${WORK}/exceptions.txt"
-          while IFS= read -r tag; do
-            [ -n "${tag}" ] || continue
-            src="${SOURCE_REPO}:${tag}"
-            safe="${tag//[^A-Za-z0-9_.-]/_}"
-            state="${WORK}/state/${safe}"
-            mkdir -p "${state}"
-            printf '%s' "${tag}" > "${state}/tag"
-
-            echo "::group::Scanning SBOMs for ${src}"
-
-            # --- Determine the platforms to scan. ------------------------------
-            manifest_json="$(crane manifest "${src}")"
-            media_type="$(printf '%s' "${manifest_json}" | jq -r '.mediaType // empty')"
-            platforms_file="${state}/platforms.tsv"   # digest<TAB>platform
-            : > "${platforms_file}"
-            case "${media_type}" in
-              *image.index*|*manifest.list*)
-                printf '%s' "${manifest_json}" | jq -r '
-                  .manifests[]
-                  | select((.platform.os // "") != "" and (.platform.os // "") != "unknown")
-                  | [ .digest, "\(.platform.os)/\(.platform.architecture)\(if .platform.variant then "/"+.platform.variant else "" end)" ]
-                  | @tsv' >> "${platforms_file}"
-                ;;
-              *)
-                printf '%s\t%s\n' "$(crane digest "${src}")" "single" >> "${platforms_file}"
-                ;;
-            esac
-
-            tag_blocking="${state}/blocking.txt"   # union across platforms
-            : > "${tag_blocking}"
-            plat_detail="${state}/platdetail.md"
-            : > "${plat_detail}"
-            missing_sbom=0
-            platform_count=0
-
-            while IFS="$(printf '\t')" read -r plat_digest plat_name; do
-              [ -n "${plat_digest}" ] || continue
-              platform_count=$((platform_count + 1))
-              echo "Platform ${plat_name} (${plat_digest})"
-
-              sbom_file="${state}/sbom-$(printf '%s' "${plat_name}" | tr '/' '_').json"
-              if ! extract_platform_sbom "${plat_digest}" "${sbom_file}"; then
-                echo "::warning::No SBOM referrer of type ${SBOM_PREDICATE_TYPE} found for ${src} (${plat_name})."
-                missing_sbom=$((missing_sbom + 1))
-                printf '| `%s` | :warning: no SBOM | — | — |\n' "${plat_name}" >> "${plat_detail}"
-                continue
-              fi
-
-              report="${state}/report-$(printf '%s' "${plat_name}" | tr '/' '_').json"
-              trivy sbom --quiet --scanners vuln --severity "${SEVERITIES}" \
-                --format json --output "${report}" "${sbom_file}"
-
-              plat_ids="${state}/ids.txt"
-              jq -r '[.Results[]?.Vulnerabilities[]?.VulnerabilityID] | unique | .[]' \
-                "${report}" | sort -u > "${plat_ids}"
-              cat "${plat_ids}" >> "${tag_blocking}"
-
-              # Per-platform counts that mirror the gate: total findings at/above
-              # the threshold, and the blocking subset after removing exceptions.
-              plat_total_ids="${state}/plattotal.txt"
-              plat_block_ids="${state}/platblock.txt"
-              sort -u "${plat_ids}" > "${plat_total_ids}"
-              comm -23 "${plat_total_ids}" "${exceptions_file}" > "${plat_block_ids}"
-              plat_total="$(wc -l < "${plat_total_ids}" | tr -d ' ')"
-              plat_block="$(wc -l < "${plat_block_ids}" | tr -d ' ')"
-              plat_block_list="$(paste -sd ',' "${plat_block_ids}" | sed 's/,/, /g')"
-              printf '| `%s` | %s | %s | %s |\n' \
-                "${plat_name}" "${plat_total}" "${plat_block}" "${plat_block_list:-—}" >> "${plat_detail}"
-            done < "${platforms_file}"
-            echo "::endgroup::"
-
-            printf '%s' "${missing_sbom}" > "${state}/missing_sbom"
-            printf '%s' "${platform_count}" > "${state}/platform_count"
-          done < "${WORK}/tags.txt"
-
-      # --- Phase 4: apply the threshold + exception gate across all platforms. -
-      # A missing SBOM is treated as a blocking failure: we cannot gate an image
-      # whose SBOM we cannot read. Records a per-tag decision (blocked | dryrun |
-      # promote) that the promote/attest/cleanup steps act on.
-      - name: Gate on scan findings
-        if: steps.enumerate.outputs.has_tags == 'true'
-        run: |
-          set -euo pipefail
-          export LC_ALL=C
-
-          exceptions_file="${WORK}/exceptions.txt"
-          for state in "${WORK}"/state/*/; do
-            [ -d "${state}" ] || continue
-            tag="$(cat "${state}/tag")"
-            missing_sbom="$(cat "${state}/missing_sbom" 2>/dev/null || echo 0)"
-
-            sort -u "${state}/blocking.txt" > "${state}/blockingall.txt"
-            comm -23 "${state}/blockingall.txt" "${exceptions_file}" > "${state}/remaining.txt"
-            comm -12 "${state}/blockingall.txt" "${exceptions_file}" > "${state}/excepted.txt"
-
-            blocking_count="$(wc -l < "${state}/blockingall.txt" | tr -d ' ')"
-            remaining_count="$(wc -l < "${state}/remaining.txt" | tr -d ' ')"
-            excepted_count="$(wc -l < "${state}/excepted.txt" | tr -d ' ')"
-            printf '%s' "${blocking_count}" > "${state}/blocking_count"
-            printf '%s' "${remaining_count}" > "${state}/remaining_count"
-            printf '%s' "${excepted_count}" > "${state}/excepted_count"
-            paste -sd '|' "${state}/excepted.txt" > "${state}/excepted_str"
-            paste -sd ',' "${state}/remaining.txt" | sed 's/,/, /g' > "${state}/remaining_md"
-            paste -sd ',' "${state}/excepted.txt" | sed 's/,/, /g' > "${state}/excepted_md"
-
-            if [ "${missing_sbom}" -gt 0 ]; then
-              echo "blocked-missing-sbom" > "${state}/decision"
-            elif [ "${remaining_count}" -gt 0 ]; then
-              echo "blocked" > "${state}/decision"
-            elif [ "${DRY_RUN}" = "true" ]; then
-              echo "dryrun" > "${state}/decision"
-            else
-              echo "promote" > "${state}/decision"
-            fi
-            echo "Gate ${SOURCE_REPO}:${tag} -> $(cat "${state}/decision") (blocking ${remaining_count}, excepted ${excepted_count}, missing SBOM ${missing_sbom})"
-          done
-
-      # --- Phase 5: promote passing images with all their referrers. ----------
-      # Skipped entirely on a dry run. `oras cp -r` carries the image and its
-      # referrers (SBOMs, provenance, VEX, signatures), per index and per
-      # platform child manifest, with retry to absorb transient registry errors.
-      - name: Promote passing images
-        if: steps.enumerate.outputs.has_tags == 'true' && !inputs.dry_run
-        run: |
-          set -euo pipefail
-          export LC_ALL=C
-
-          # --- Retry an oras cp -r to absorb transient registry errors. --------
-          # An `oras cp -r` fans out many blob requests; registries occasionally
-          # return a transient "not found"/5xx for one of them. Retry with
-          # backoff so a single flaky response does not fail promotion.
-          oras_cp_retry() {
-            local attempt=1 max=4 delay=5
-            while true; do
-              if oras cp -r "$1" "$2"; then
-                return 0
-              fi
-              if [ "${attempt}" -ge "${max}" ]; then
-                echo "::error::oras cp -r '$1' -> '$2' failed after ${max} attempts."
-                return 1
-              fi
-              echo "::warning::oras cp -r '$1' -> '$2' failed (attempt ${attempt}/${max}); retrying in ${delay}s."
-              sleep "${delay}"
-              attempt=$((attempt + 1))
-              delay=$((delay * 2))
-            done
-          }
-
-          # --- Copy an image and all its referrers from source to destination. --
-          # Mirrors the oras-based copy used by _mirror-image.yml: copy the index
-          # plus its referrers, then each per-platform child manifest plus its
-          # own referrers (DHI attestations are attached per platform).
-          copy_with_referrers() {
-            local src_ref="$1" dst_ref="$2"
-            oras_cp_retry "${src_ref}" "${dst_ref}"
-            local child
-            for child in $(crane manifest "${src_ref}" | jq -r '.manifests[]?.digest // empty'); do
-              [ -n "${child}" ] || continue
-              oras_cp_retry "${SOURCE_REPO}@${child}" "${DEST_REPO}@${child}"
-            done
-          }
-
-          for state in "${WORK}"/state/*/; do
-            [ -d "${state}" ] || continue
-            [ "$(cat "${state}/decision")" = "promote" ] || continue
-            tag="$(cat "${state}/tag")"
-            src="${SOURCE_REPO}:${tag}"
-            dest="${DEST_REPO}:${tag}"
-            echo "Promoting ${src} -> ${dest} (with referrers)"
-            copy_with_referrers "${src}" "${dest}"
-            printf '%s' "${dest}" > "${state}/promoted"
-          done
-
-      # --- Phase 6: attach the scan-report referrer to promoted images. -------
       - name: Attach scan-report attestation
-        if: steps.enumerate.outputs.has_tags == 'true' && !inputs.dry_run
-        run: |
-          set -euo pipefail
-          export LC_ALL=C
+        if: steps.evaluate.outputs.decision == 'promote'
+        uses: ./.github/actions/attach-scan-report
+        with:
+          image-ref: ${{ inputs.dest_repo }}:${{ matrix.tag }}
+          source-repo: ${{ inputs.source_repo }}
+          tag: ${{ matrix.tag }}
+          threshold: ${{ inputs.severity_threshold }}
+          excepted-str: ${{ steps.evaluate.outputs.excepted-str }}
+          scanner-version: ${{ steps.prepare.outputs.trivy-resolved }}
+          method: sbom
+          sbom-predicate-type: ${{ inputs.sbom_predicate_type }}
 
-          for state in "${WORK}"/state/*/; do
-            [ -d "${state}" ] || continue
-            [ -f "${state}/promoted" ] || continue
-            tag="$(cat "${state}/tag")"
-            dest="$(cat "${state}/promoted")"
-            excepted_str="$(cat "${state}/excepted_str")"
-            created="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
-            echo "Attaching scan report to ${dest}"
-            oras attach --artifact-type application/vnd.cssc.scan-report.v1+json \
-              --annotation "org.opencontainers.image.created=${created}" \
-              --annotation "com.cssc.scan.source=${SOURCE_REPO}" \
-              --annotation "com.cssc.scan.tag=${tag}" \
-              --annotation "com.cssc.scan.threshold=${THRESHOLD}" \
-              --annotation "com.cssc.scan.exceptions=${excepted_str}" \
-              --annotation "com.cssc.scan.scanner=trivy" \
-              --annotation "com.cssc.scan.scanner-version=${TRIVY_RESOLVED}" \
-              --annotation "com.cssc.scan.method=sbom" \
-              --annotation "com.cssc.scan.sbom-predicate-type=${SBOM_PREDICATE_TYPE}" \
-              "${dest}"
-          done
+      - name: Delete promoted tag from quarantine
+        id: delete
+        if: steps.evaluate.outputs.decision == 'promote' && inputs.delete_source
+        uses: ./.github/actions/delete-image
+        with:
+          repository: ${{ inputs.source_repo }}
+          tag: ${{ matrix.tag }}
+          token: ${{ secrets.ghcr_delete_token }}
 
-      # --- Phase 7: delete promoted tags from quarantine. ---------------------
-      - name: Delete promoted tags from quarantine
-        if: steps.enumerate.outputs.has_tags == 'true' && !inputs.dry_run && inputs.delete_source
+      - name: Record result
+        if: always()
         env:
-          DELETE_TOKEN: "${{ secrets.ghcr_delete_token }}"
+          DECISION: "${{ steps.evaluate.outputs.decision }}"
+          BLOCKING_COUNT: "${{ steps.evaluate.outputs.blocking-count }}"
+          REMAINING_COUNT: "${{ steps.evaluate.outputs.remaining-count }}"
+          EXCEPTED_COUNT: "${{ steps.evaluate.outputs.excepted-count }}"
+          REMAINING_MD: "${{ steps.evaluate.outputs.remaining-md }}"
+          EXCEPTED_MD: "${{ steps.evaluate.outputs.excepted-md }}"
+          PLATFORM_COUNT: "${{ steps.scan.outputs.platform-count }}"
+          MISSING_SBOM: "${{ steps.scan.outputs.missing-sbom-count }}"
+          PLATFORM_DETAIL_PATH: "${{ steps.scan.outputs.platform-detail-path }}"
+          DEL_STATUS: "${{ steps.delete.outputs.status }}"
         run: |
           set -euo pipefail
           export LC_ALL=C
 
-          delete_quarantine_tag() {
-            local tag="$1" base vid
-            if [ "${OWNER_TYPE}" = "Organization" ]; then
-              base="orgs/${PKG_OWNER}/packages/container/${PKG_ENC}"
-            else
-              base="user/packages/container/${PKG_ENC}"
-            fi
-            vid="$(GH_TOKEN="${DELETE_TOKEN}" gh api --paginate "${base}/versions" \
-                   --jq ".[] | select(.metadata.container.tags[]? == \"${tag}\") | .id" 2>/dev/null \
-                   | head -n1 || true)"
-            if [ -z "${vid}" ]; then
-              echo "::warning::Could not resolve a package version id for tag '${tag}'; skipping deletion."
-              return 1
-            fi
-            GH_TOKEN="${DELETE_TOKEN}" gh api -X DELETE "${base}/versions/${vid}" >/dev/null
+          safe="${TAG//[^A-Za-z0-9_.-]/_}"
+          out="${RUNNER_TEMP}/result/${safe}"
+          mkdir -p "${out}"
+
+          src="${SOURCE_REPO}:${TAG}"
+          dest="${DEST_REPO}:${TAG}"
+          decision="${DECISION:-unknown}"
+          blocking_count="${BLOCKING_COUNT:-0}"
+          remaining_count="${REMAINING_COUNT:-0}"
+          excepted_count="${EXCEPTED_COUNT:-0}"
+          remaining_md="${REMAINING_MD:-}"
+          excepted_md="${EXCEPTED_MD:-}"
+          platform_count="${PLATFORM_COUNT:-0}"
+          missing_sbom="${MISSING_SBOM:-0}"
+
+          case "${decision}" in
+            blocked-missing-sbom)
+              result_class="blocked"; result="blocked (missing SBOM)"; icon=":no_entry:"
+              promoted_yesno="no (left in quarantine)" ;;
+            blocked)
+              result_class="blocked"; result="blocked"; icon=":no_entry:"
+              promoted_yesno="no (left in quarantine)" ;;
+            dryrun)
+              result_class="promoted"; result="would promote"; icon=":mag:"
+              promoted_yesno="no (dry run)" ;;
+            promote)
+              result_class="promoted"
+              result="promoted (source ${DEL_STATUS:-kept})"
+              icon=":white_check_mark:"
+              promoted_yesno="yes → ${dest}" ;;
+            *)
+              result_class="unknown"; result="unknown (scan failed?)"; icon=":grey_question:"
+              promoted_yesno="—" ;;
+          esac
+          printf '%s' "${result_class}" > "${out}/result_class"
+          printf '%s' "${TRIVY_RESOLVED:-}" > "${out}/scanner"
+
+          # --- Human-readable report to the run log. ---------------------------
+          {
+            echo "================================================================"
+            echo "Image:            ${src}"
+            echo "Result:           ${result}"
+            echo "Promoted:         ${promoted_yesno}"
+            echo "SBOM predicate:   ${SBOM_PREDICATE_TYPE}"
+            echo "Platforms:        ${platform_count} (missing SBOM: ${missing_sbom})"
+            echo "Threshold:        ${THRESHOLD} (severities: ${SEVERITIES})"
+            echo "CVEs ≥ ${THRESHOLD}:   ${blocking_count} (blocking: ${remaining_count}, excepted: ${excepted_count})"
           }
 
-          for state in "${WORK}"/state/*/; do
-            [ -d "${state}" ] || continue
-            [ -f "${state}/promoted" ] || continue
-            tag="$(cat "${state}/tag")"
-            if [ -z "${DELETE_TOKEN}" ]; then
-              echo "::warning::delete_source=true but no ghcr_delete_token provided; skipping deletion of ${SOURCE_REPO}:${tag}."
-              printf '%s' "skipped (no token)" > "${state}/del_status"
-            elif delete_quarantine_tag "${tag}"; then
-              printf '%s' "deleted" > "${state}/del_status"
-            else
-              printf '%s' "delete failed" > "${state}/del_status"
-            fi
-          done
+          # --- Summary table row. ----------------------------------------------
+          printf '| `%s` | %s %s | %s | %s | %s | %s |\n' \
+            "${TAG}" "${icon}" "${result}" "${platform_count}" "${blocking_count}" \
+            "${remaining_md:-—}" "${excepted_md:-—}" > "${out}/row.md"
 
-      # --- Phase 8: render the run log and job summary. -----------------------
-      # Runs even if an earlier phase failed (as long as tags were enumerated)
-      # so partial results are still reported.
+          # --- Collapsible per-image detail for the job summary. ----------------
+          {
+            echo ""
+            echo "<details><summary><code>${TAG}</code> — ${icon} ${result} · ${blocking_count} CVE(s) ≥ ${THRESHOLD} across ${platform_count} platform(s)</summary>"
+            echo ""
+            echo "- **Source:** \`${src}\`"
+            echo "- **Destination:** \`${dest}\`"
+            echo "- **Promoted:** ${promoted_yesno}"
+            echo "- **SBOM predicate type:** \`${SBOM_PREDICATE_TYPE}\`"
+            echo "- **Blocking (not excepted):** ${remaining_count} · **Excepted:** ${excepted_count}"
+            echo ""
+            echo "| Platform | CVEs ≥ ${THRESHOLD} | Blocking | Blocking CVE IDs |"
+            echo "| --- | --- | --- | --- |"
+            if [ -n "${PLATFORM_DETAIL_PATH}" ] && [ -s "${PLATFORM_DETAIL_PATH}" ]; then
+              cat "${PLATFORM_DETAIL_PATH}"
+            else
+              echo "| — | — | — | (no platform detail recorded) |"
+            fi
+            echo ""
+            echo "</details>"
+          } > "${out}/detail.md"
+
+      - name: Upload result
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: scan-result-${{ strategy.job-index }}
+          path: ${{ runner.temp }}/result
+          retention-days: 1
+
+  # --- Phase 3: aggregate the per-tag results into one job summary. -----------
+  summary:
+    needs: [enumerate, scan]
+    if: always() && needs.enumerate.outputs.has-tags == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download results
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          pattern: scan-result-*
+          path: ${{ runner.temp }}/results
+          merge-multiple: true
+
       - name: Write job summary
-        if: always() && steps.enumerate.outputs.has_tags == 'true'
+        env:
+          SOURCE_REPO: "${{ inputs.source_repo }}"
+          DEST_REPO: "${{ inputs.dest_repo }}"
+          THRESHOLD: "${{ inputs.severity_threshold }}"
+          SEVERITIES: "${{ needs.enumerate.outputs.severities }}"
+          SBOM_PREDICATE_TYPE: "${{ inputs.sbom_predicate_type }}"
+          DRY_RUN: "${{ inputs.dry_run }}"
         run: |
           set -euo pipefail
           export LC_ALL=C
 
+          results="${RUNNER_TEMP}/results"
           promoted=0
           blocked=0
-          rows="${WORK}/rows.md"
-          details_md="${WORK}/details.md"
+          scanner=""
+          rows="${RUNNER_TEMP}/rows.md"
+          details_md="${RUNNER_TEMP}/details.md"
           : > "${rows}"
           : > "${details_md}"
 
-          for state in "${WORK}"/state/*/; do
-            [ -d "${state}" ] || continue
-            tag="$(cat "${state}/tag")"
-            src="${SOURCE_REPO}:${tag}"
-            dest="${DEST_REPO}:${tag}"
-            decision="$(cat "${state}/decision" 2>/dev/null || echo "")"
-            blocking_count="$(cat "${state}/blocking_count" 2>/dev/null || echo 0)"
-            remaining_count="$(cat "${state}/remaining_count" 2>/dev/null || echo 0)"
-            excepted_count="$(cat "${state}/excepted_count" 2>/dev/null || echo 0)"
-            platform_count="$(cat "${state}/platform_count" 2>/dev/null || echo 0)"
-            missing_sbom="$(cat "${state}/missing_sbom" 2>/dev/null || echo 0)"
-            remaining_md="$(cat "${state}/remaining_md" 2>/dev/null || true)"
-            excepted_md="$(cat "${state}/excepted_md" 2>/dev/null || true)"
-
-            case "${decision}" in
-              blocked-missing-sbom)
-                blocked=$((blocked + 1))
-                result="blocked (missing SBOM)"
-                icon=":no_entry:"
-                promoted_yesno="no (left in quarantine)" ;;
-              blocked)
-                blocked=$((blocked + 1))
-                result="blocked"
-                icon=":no_entry:"
-                promoted_yesno="no (left in quarantine)" ;;
-              dryrun)
-                promoted=$((promoted + 1))
-                result="would promote"
-                icon=":mag:"
-                promoted_yesno="no (dry run)" ;;
-              promote)
-                promoted=$((promoted + 1))
-                del_status="$(cat "${state}/del_status" 2>/dev/null || echo "kept")"
-                result="promoted (source ${del_status})"
-                icon=":white_check_mark:"
-                promoted_yesno="yes → ${dest}" ;;
-              *)
-                result="unknown"
-                icon=":grey_question:"
-                promoted_yesno="—" ;;
+          for d in "${results}"/*/; do
+            [ -d "${d}" ] || continue
+            [ -f "${d}/row.md" ] || continue
+            cat "${d}/row.md" >> "${rows}"
+            [ -f "${d}/detail.md" ] && cat "${d}/detail.md" >> "${details_md}"
+            [ -z "${scanner}" ] && [ -f "${d}/scanner" ] && scanner="$(cat "${d}/scanner")"
+            case "$(cat "${d}/result_class" 2>/dev/null || echo unknown)" in
+              promoted) promoted=$((promoted + 1)) ;;
+              blocked)  blocked=$((blocked + 1)) ;;
             esac
-
-            # --- Human-readable report to the run log. -------------------------
-            {
-              echo "================================================================"
-              echo "Image:            ${src}"
-              echo "Result:           ${result}"
-              echo "Promoted:         ${promoted_yesno}"
-              echo "SBOM predicate:   ${SBOM_PREDICATE_TYPE}"
-              echo "Platforms:        ${platform_count} (missing SBOM: ${missing_sbom})"
-              echo "Threshold:        ${THRESHOLD} (severities: ${SEVERITIES})"
-              echo "CVEs ≥ ${THRESHOLD}:   ${blocking_count} (blocking: ${remaining_count}, excepted: ${excepted_count})"
-            }
-
-            # --- Summary table row. --------------------------------------------
-            printf '| `%s` | %s %s | %s | %s | %s | %s |\n' \
-              "${tag}" "${icon}" "${result}" "${platform_count}" "${blocking_count}" \
-              "${remaining_md:-—}" "${excepted_md:-—}" >> "${rows}"
-
-            # --- Collapsible per-image detail for the job summary. -------------
-            {
-              echo ""
-              echo "<details><summary><code>${tag}</code> — ${icon} ${result} · ${blocking_count} CVE(s) ≥ ${THRESHOLD} across ${platform_count} platform(s)</summary>"
-              echo ""
-              echo "- **Source:** \`${src}\`"
-              echo "- **Destination:** \`${dest}\`"
-              echo "- **Promoted:** ${promoted_yesno}"
-              echo "- **SBOM predicate type:** \`${SBOM_PREDICATE_TYPE}\`"
-              echo "- **Blocking (not excepted):** ${remaining_count} · **Excepted:** ${excepted_count}"
-              echo ""
-              echo "| Platform | CVEs ≥ ${THRESHOLD} | Blocking | Blocking CVE IDs |"
-              echo "| --- | --- | --- | --- |"
-              # The scan step may have failed before writing platdetail.md (e.g. a
-              # `crane manifest` error). Guard the read so this always()-summary
-              # still renders instead of aborting under `set -e`.
-              if [ -s "${state}/platdetail.md" ]; then
-                cat "${state}/platdetail.md"
-              else
-                echo "| — | — | — | (no platform detail recorded) |"
-              fi
-              echo ""
-              echo "</details>"
-            } >> "${details_md}"
           done
 
           {
@@ -589,7 +408,7 @@ jobs:
             echo "- **Scan method:** SBOM (\`trivy sbom\`)"
             echo "- **SBOM predicate type:** \`${SBOM_PREDICATE_TYPE}\`"
             echo "- **Threshold:** \`${THRESHOLD}\` (severities scanned: \`${SEVERITIES}\`)"
-            echo "- **Scanner:** trivy \`${TRIVY_RESOLVED}\`"
+            if [ -n "${scanner}" ]; then echo "- **Scanner:** trivy \`${scanner}\`"; fi
             echo "- **Dry run:** \`${DRY_RUN}\`"
             echo "- **Promoted:** ${promoted} · **Blocked:** ${blocked}"
             echo ""

--- a/docs/architecture/workflows/image-mirror-workflows.md
+++ b/docs/architecture/workflows/image-mirror-workflows.md
@@ -21,16 +21,23 @@ rather than pulling directly from Docker Hub.
 
 ## How are the actions structured
 
-The mirror workflows follow a **caller + reusable workflow** pattern. All shared
-logic lives in a single reusable workflow, and each mirrored image gets a thin
-caller workflow that only supplies configuration.
+The mirror workflows follow a **caller + reusable workflow** pattern, and the
+reusable workflow is in turn assembled from small, single-purpose **composite
+actions** under [`.github/actions/`](../../../.github/actions/) (see the
+[action catalogue](../../reference/workflow-actions.md)). All shared logic lives
+in the composite actions; the reusable workflow orchestrates them, and each
+mirrored image gets a thin caller workflow that only supplies configuration.
 
 ```text
-.github/workflows/
-├── _mirror-image.yml     # reusable workflow — all the logic
-├── mirror-python.yml     # caller — docker.io/library/python  → quarantine/python
-├── mirror-node.yml       # caller — docker.io/library/node    → quarantine/node
-└── mirror-openjdk.yml    # caller — docker.io/library/openjdk → quarantine/openjdk
+.github/
+├── actions/                 # composite actions (reusable steps)
+│   ├── registry-login/
+│   └── mirror-image/
+└── workflows/
+    ├── _mirror-image.yml     # reusable workflow — orchestrates the actions
+    ├── mirror-python.yml     # caller — docker.io/library/python  → quarantine/python
+    ├── mirror-node.yml       # caller — docker.io/library/node    → quarantine/node
+    └── mirror-openjdk.yml    # caller — docker.io/library/openjdk → quarantine/openjdk
 ```
 
 ### Reusable workflow (`_mirror-image.yml`)
@@ -59,17 +66,21 @@ It also accepts two optional secrets, used only for authenticated sources:
 It defines a single `mirror` job that runs on `ubuntu-latest` with the minimal
 permissions `contents: read` and `packages: write`, and performs these steps:
 
-1. **Set up crane** — installs the `crane` CLI.
-2. **Set up oras** — installs `oras`, only when `copy_referrers` is `true`.
-3. **Log in to source registry** — only when `source_login_registry` is set
-   (e.g. Docker Hardened Images on `dhi.io`); authenticates `crane` (and `oras`
-   when copying referrers).
-4. **Log in to GHCR** — authenticates to `ghcr.io` using the built-in
-   `GITHUB_TOKEN` and the triggering actor.
-5. **Compare digests and copy if changed** — the core idempotent-sync logic
+1. **Check out actions** — checks out the repository so the local composite
+   actions are available.
+2. **Set up crane** — installs the `crane` CLI.
+3. **Set up oras** — installs `oras`, only when `copy_referrers` is `true`.
+4. **Log in to source registry** (`registry-login`) — only when
+   `source_login_registry` is set (e.g. Docker Hardened Images on `dhi.io`);
+   authenticates `crane` (and `oras` when copying referrers).
+5. **Log in to GHCR** (`registry-login`) — authenticates to `ghcr.io` using the
+   built-in `GITHUB_TOKEN` and the triggering actor.
+6. **Mirror image** (`mirror-image`) — the core idempotent-sync logic
    (described below). When `copy_referrers` is `true` the copy uses
    `oras cp -r` for the index and each per-platform child manifest so the
    attached referrers travel with the image; otherwise it uses `crane copy`.
+7. **Write job summary** — renders the copied / up-to-date outcome from the
+   `mirror-image` outputs.
 
 ### Caller workflows (`mirror-<image>.yml`)
 
@@ -104,13 +115,13 @@ flowchart TD
     A[schedule 06:00 UTC] --> C[caller mirror-image.yml]
     B[workflow_dispatch + force] --> C
     C -->|uses: with inputs| D[_mirror-image.yml]
-    D --> E[setup crane]
-    E --> F[crane auth login ghcr.io]
-    F --> G[crane digest source]
+    D --> E[checkout + setup crane]
+    E --> F[registry-login ghcr.io]
+    F --> G[mirror-image: crane digest source]
     G --> H[crane digest destination]
     H --> I{force or digests differ?}
     I -->|no| J[skip: up to date]
-    I -->|yes| K[crane copy source dest]
+    I -->|yes| K[crane copy / oras cp -r]
     K --> L[write job summary]
     J --> L
 ```

--- a/docs/architecture/workflows/scan-and-promote-workflows.md
+++ b/docs/architecture/workflows/scan-and-promote-workflows.md
@@ -209,8 +209,8 @@ source deletion, and reporting) with these differences:
   `oras cp -r` (index plus per-platform children) so the SBOMs, provenance, VEX,
   and signatures travel into the destination alongside the scan-report referrer.
 
-The scan-report referrer adds two annotations on top of the common set:
-`com.cssc.scan.method=sbom` and
+The scan-report referrer records the scan method in `com.cssc.scan.method`
+(`image` for `_scan-image.yml`, `sbom` here) and, for SBOM scans, adds
 `com.cssc.scan.sbom-predicate-type=<predicate type>`.
 
 The `scan-hardened-python.yml` caller wires this workflow for
@@ -259,6 +259,7 @@ referrer of the image.
 | `com.cssc.scan.exceptions` | `CVE-2024-1234\|CVE-2024-5678` | Pipe-separated CVEs found in the image at/above the threshold but cleared via the exception list (empty if none). |
 | `com.cssc.scan.scanner` | `trivy` | Scanner name. |
 | `com.cssc.scan.scanner-version` | `0.52.0` | Scanner version. |
+| `com.cssc.scan.method` | `image` | Scan method: `image` (filesystem) or `sbom` (SBOM attestation). |
 
 ## What functionality is implemented and what is not
 

--- a/docs/architecture/workflows/scan-and-promote-workflows.md
+++ b/docs/architecture/workflows/scan-and-promote-workflows.md
@@ -42,18 +42,30 @@ referrer describing the decision.
 ## How are the actions structured
 
 The scan-and-promote workflows follow the same **caller + reusable workflow**
-pattern as the mirror workflows. All shared logic lives in one reusable
-workflow, and each scanned repository gets a thin caller that only supplies
-configuration.
+pattern as the mirror workflows, and the reusable workflows are assembled from
+small, single-purpose **composite actions** under
+[`.github/actions/`](../../../.github/actions/) (see the
+[action catalogue](../../reference/workflow-actions.md)). Each scanned
+repository gets a thin caller that only supplies configuration.
 
 ```text
-.github/workflows/
-├── _scan-image.yml          # reusable workflow — image-filesystem scan
-├── _scan-sbom-image.yml     # reusable workflow — SBOM-attestation scan (hardened images)
-├── scan-python.yml          # caller — quarantine/python  → golden/python
-├── scan-node.yml            # caller — quarantine/node    → golden/node
-├── scan-openjdk.yml         # caller — quarantine/openjdk → golden/openjdk
-└── scan-hardened-python.yml # caller — quarantine/hardened/python → base/hardened/python (SBOM-based)
+.github/
+├── actions/                  # composite actions (reusable steps)
+│   ├── registry-login/
+│   ├── enumerate-tags/
+│   ├── scan-image/
+│   ├── scan-sbom/
+│   ├── evaluate-findings/
+│   ├── mirror-image/         # also used to promote (force: true)
+│   ├── attach-scan-report/
+│   └── delete-image/
+└── workflows/
+    ├── _scan-image.yml          # reusable workflow — image-filesystem scan
+    ├── _scan-sbom-image.yml     # reusable workflow — SBOM-attestation scan (hardened images)
+    ├── scan-python.yml          # caller — quarantine/python  → golden/python
+    ├── scan-node.yml            # caller — quarantine/node    → golden/node
+    ├── scan-openjdk.yml         # caller — quarantine/openjdk → golden/openjdk
+    └── scan-hardened-python.yml # caller — quarantine/hardened/python → base/hardened/python (SBOM-based)
 ```
 
 - **Display name:** `scan / quarantine/<image>` (e.g. `scan / quarantine/python`).
@@ -84,19 +96,24 @@ It also accepts one optional secret:
 | ------ | -------- | ----------- |
 | `ghcr_delete_token` | no | PAT with `delete:packages` used to delete quarantine tags via the GitHub Packages REST API. When absent, deletion is skipped with a warning (see [source deletion](#source-deletion)). |
 
-The reusable workflow defines a single `scan` job running on `ubuntu-latest`
-with minimal permissions (`contents: read`, `packages: write`). It performs:
+The reusable workflow defines three jobs running on `ubuntu-latest` with minimal
+permissions (`contents: read`, `packages: write`). It fans the work out across a
+job matrix so each tag is processed in its own parallel job:
 
-1. **Set up tooling** — installs `crane`, `oras`, and `trivy` (all pinned).
-2. **Log in to GHCR** — authenticates `crane`, `oras`, and Trivy to `ghcr.io`
-   using the built-in `GITHUB_TOKEN` and the triggering actor.
-3. **Enumerate and process tags** — the core scan/gate/promote loop described
-   below.
-4. **Write a report** — a human-readable per-image report to the run log and a
-   job summary that combines a one-row-per-tag overview table with a collapsible
-   per-image vulnerability detail (every CVE found at or above the threshold,
-   its severity, package, installed/fixed versions, and whether it was blocking
-   or excepted).
+1. **`enumerate`** — logs in to GHCR (`registry-login`), resolves the severity
+   set from the threshold, and lists the quarantine tags (`enumerate-tags`),
+   emitting them as a JSON array for the matrix.
+2. **`scan`** — runs once per tag (`strategy.matrix`, `fail-fast: false`):
+   sets up `crane`/`oras`/`trivy`, logs in, scans the image
+   (`scan-image`), applies the gate (`evaluate-findings`), and — for passing
+   images — promotes it (`mirror-image` with `force: true`), attaches the
+   scan-report referrer (`attach-scan-report`), and deletes the source
+   (`delete-image`). Each job uploads a small result artifact.
+3. **`summary`** — downloads every result artifact and renders one aggregated
+   job summary: a one-row-per-tag overview table plus a collapsible per-image
+   vulnerability detail (every CVE found at or above the threshold, its
+   severity, package, installed/fixed versions, and whether it was blocking or
+   excepted).
 
 ### Caller workflows (`scan-<image>.yml`)
 
@@ -116,31 +133,30 @@ with no logic changes.
 
 ### Control flow
 
-The job lists every tag in `source_repo` and processes each one independently:
+The `enumerate` job lists every tag in `source_repo` and emits them as a matrix;
+the `scan` job then processes each tag independently and in parallel, and the
+`summary` job aggregates the results:
 
 ```mermaid
 flowchart TD
     A[schedule 07:00 UTC] --> C[caller scan-image.yml]
     B[workflow_dispatch + overrides] --> C
     C -->|uses: with inputs| D[_scan-image.yml]
-    D --> E[setup crane + oras + trivy]
-    E --> F[login ghcr.io]
-    F --> G[crane ls source_repo]
-    G --> H[for each tag]
-    H --> I[trivy image --format json --severity threshold..CRITICAL]
-    I --> J[blocking = findings at/above threshold]
-    J --> K[excepted_found = blocking ∩ cve_exceptions]
-    K --> L[remaining = blocking − cve_exceptions]
-    L --> M{remaining empty?}
-    M -->|no| N[BLOCKED: stays in quarantine, report CVEs]
-    M -->|yes| O[crane copy source:tag → dest:tag]
-    O --> P[oras attach scan-report referrer to dest:tag]
-    P --> Q{delete_source and token present?}
-    Q -->|yes| R[delete source:tag via Packages REST API]
-    Q -->|no| S[keep source:tag, warn]
-    N --> T[job summary]
-    R --> T
-    S --> T
+    D --> E[enumerate job: login + enumerate-tags]
+    E -->|tags-json matrix| F[scan job: one parallel job per tag]
+    F --> G[scan-image: trivy image]
+    G --> H[evaluate-findings: threshold + exceptions]
+    H --> I{decision}
+    I -->|blocked| J[stays in quarantine, report CVEs]
+    I -->|promote| K[mirror-image: copy source -> dest]
+    K --> L[attach-scan-report referrer]
+    L --> M{delete_source and token present?}
+    M -->|yes| N[delete-image source:tag]
+    M -->|no| O[keep source:tag, warn]
+    J --> P[upload result artifact]
+    N --> P
+    O --> P
+    P --> Q[summary job: aggregate into job summary]
 ```
 
 ### Gate semantics

--- a/docs/contributing/workflow-naming.md
+++ b/docs/contributing/workflow-naming.md
@@ -14,6 +14,7 @@ both in the file system and in the Actions UI.
 | **Scan** | Scan a quarantined image and promote it into `golden/<image>` when it passes the vulnerability policy | `scan-<image>.yml` | `scan / quarantine/<image>` | `scan-quarantine-<image>` |
 | **Build** | Build an application image on top of a mirrored base | `build-<app>.yml` | `build / <app>` | `build-<app>` |
 | **Reusable** | Shared logic invoked by other workflows; never triggered directly | `_<purpose>.yml` (leading underscore) | `_reusable / <purpose>` | n/a |
+| **Composite action** | A single reusable step shared across workflows | `.github/actions/<verb-noun>/action.yml` | `name: <verb-noun>` | n/a |
 
 ### Rules
 
@@ -38,7 +39,9 @@ both in the file system and in the Actions UI.
 Mirror workflows keep a copy of an upstream base image fresh in GHCR.
 
 - **Structure.** Logic lives in a single reusable workflow,
-  [`_mirror-image.yml`](../../.github/workflows/_mirror-image.yml). Each image
+  [`_mirror-image.yml`](../../.github/workflows/_mirror-image.yml), which is
+  assembled from composite actions under `.github/actions/` (see
+  [workflow actions](../reference/workflow-actions.md)). Each image
   has a thin caller, e.g.
   [`mirror-python.yml`](../../.github/workflows/mirror-python.yml), that only
   declares triggers and the image-specific inputs and calls the reusable
@@ -66,7 +69,10 @@ configurable severity threshold (plus an optional CVE exception list) into a
 `golden/<image>` repository.
 
 - **Structure.** Logic lives in a single reusable workflow,
-  [`_scan-image.yml`](../../.github/workflows/_scan-image.yml). Each scanned
+  [`_scan-image.yml`](../../.github/workflows/_scan-image.yml), which is
+  assembled from composite actions under `.github/actions/` (see
+  [workflow actions](../reference/workflow-actions.md)) and fans the work out
+  across a job matrix (one job per tag). Each scanned
   repository has a thin caller, e.g.
   [`scan-python.yml`](../../.github/workflows/scan-python.yml), that only
   declares triggers and the repository-specific inputs and calls the reusable
@@ -95,3 +101,28 @@ Build workflows (added later) build the demo applications under `apps/` on top
 of the mirrored base images. They use the `build-<app>.yml` filename and the
 `build / <app>` display name so they remain clearly separate from mirror
 workflows.
+
+## Composite actions
+
+The reusable steps shared across workflows live as **composite actions** under
+[`.github/actions/`](../../.github/actions/), one directory per action with an
+`action.yml` inside. They are the single source of truth for each operation
+(login, enumerate, copy, scan, gate, attach, delete); the reusable workflows
+only orchestrate them.
+
+### Rules
+
+1. **One verb-noun per action.** Action directory and `name:` use the standard
+   terminology verb-noun, e.g. `registry-login`, `enumerate-tags`,
+   `mirror-image`, `scan-image`, `scan-sbom`, `evaluate-findings`,
+   `attach-scan-report`, `delete-image`. The canonical glossary lives in
+   [workflow actions and terminology](../reference/workflow-actions.md).
+2. **kebab-case** for action directory names, inputs, and outputs.
+3. **Single responsibility.** An action does one thing on one image/repository;
+   looping over many tags is the orchestrating workflow's job (via a matrix).
+4. **No tool setup inside actions.** Actions assume the calling job has already
+   checked out the repo and installed the CLIs they need (`crane`, `oras`,
+   `trivy`); this lets several actions share one setup.
+5. **Document every action** in
+   [workflow actions and terminology](../reference/workflow-actions.md) when it
+   is added or its interface changes.

--- a/docs/reference/README.md
+++ b/docs/reference/README.md
@@ -2,4 +2,6 @@
 
 Reference material and conventions for the `cssc-framework` repository.
 
-> Placeholder — add reference docs here.
+- [Workflow actions and terminology](workflow-actions.md) — the composite-action
+  catalogue under `.github/actions/`, the standard terminology (verbs and
+  nouns), and how the reusable workflows compose the actions.

--- a/docs/reference/workflow-actions.md
+++ b/docs/reference/workflow-actions.md
@@ -1,0 +1,197 @@
+# Workflow actions and terminology
+
+This repository's GitHub Actions are built from small, single-purpose
+**composite actions** under [`.github/actions/`](../../.github/actions/). The
+reusable workflows (`_*.yml`) orchestrate these actions; the per-image callers
+(`mirror-*.yml`, `scan-*.yml`) only supply configuration.
+
+This document is the canonical reference for:
+
+1. [Terminology](#terminology) — the standard verbs and nouns used in action
+   names, step names, inputs, and docs.
+2. [Action catalogue](#action-catalogue) — what each composite action does and
+   its inputs/outputs.
+3. [How the actions compose](#how-the-actions-compose) — how the reusable
+   workflows wire the actions together.
+
+## Terminology
+
+Use these terms consistently across workflows, actions, commit messages, and
+docs. The left column is the canonical term; the right column lists the older
+phrasings it replaces.
+
+| Canonical term | Meaning | Replaces |
+| -------------- | ------- | -------- |
+| **registry-login** | Authenticate the local clients to a registry. | "Log in to GHCR", "Log in to source registry" |
+| **enumerate-tags** | List the tags in a repository. | "Enumerate quarantine tags", "list tags" |
+| **mirror-image** | Idempotently copy one image between registries (digest-compare + copy). | "compare digests and copy", "crane copy" |
+| **promote-image** | Copy a passing image from quarantine into golden/base. Implemented as **mirror-image** with `force: true`. | "promote", "promote passing images" |
+| **copy-referrers** | Copy an image together with its OCI referrers (`oras cp -r` + per-platform children). Folded into **mirror-image** via `copy-referrers: true`. | "copy_referrers", "copy with referrers" |
+| **scan-image** | Scan one image filesystem with `trivy image`. | "scan images with Trivy" |
+| **scan-sbom** | Scan one image's per-platform SBOM attestations with `trivy sbom`. | "scan platform SBOMs" |
+| **evaluate-findings** | Apply the severity threshold + CVE exceptions to produce a gate decision. | "gate on scan findings" |
+| **attach-scan-report** | Attach the OCI scan-report referrer to a promoted image. | "attach scan-report attestation" |
+| **delete-image** | Delete one tag from a GHCR repository via the Packages API. | "delete promoted tags from quarantine" |
+
+Standard nouns:
+
+- **image** — one tagged artifact (`repository:tag`).
+- **repository** — an untagged repository (`registry/owner/path`).
+- **tag**, **digest**, **referrers** — as in the OCI spec.
+- **quarantine** — the untrusted landing repository (`quarantine/<image>`).
+- **golden** / **base** — promotion targets for clean images (`golden/<image>`,
+  `base/hardened/<image>`).
+- **decision** — the gate outcome: `promote`, `dryrun`, `blocked`, or
+  `blocked-missing-sbom`.
+
+## Action catalogue
+
+All actions are composite actions invoked with `uses: ./.github/actions/<name>`.
+They assume the relevant CLIs (`crane`, `oras`, `trivy`, `jq`, `gh`) are already
+installed by the calling job, and that the repository has been checked out (with
+`actions/checkout`) so the local action files are on disk.
+
+### registry-login
+
+Log in to a container registry with `crane` (and optionally `oras`).
+
+| Input | Required | Default | Description |
+| ----- | -------- | ------- | ----------- |
+| `registry` | yes | — | Registry hostname (e.g. `ghcr.io`, `dhi.io`). |
+| `username` | yes | — | Registry username. |
+| `password` | yes | — | Password/token (passed via stdin). |
+| `with-oras` | no | `false` | Also log in `oras`. |
+
+### enumerate-tags
+
+List the tags in a repository as a JSON array for matrix fan-out.
+
+| Input | Required | Default | Description |
+| ----- | -------- | ------- | ----------- |
+| `repository` | yes | — | Repository to enumerate, without tag. |
+| `exclude-referrer-tags` | no | `false` | Drop OCI referrer fallback tags (`sha256-*`). |
+
+Outputs: `tags-json` (JSON array), `has-tags` (`true`/`false`).
+
+### mirror-image
+
+Idempotently copy one image (optionally with its referrers) between registries.
+Backs both the upstream → quarantine mirror and the quarantine → golden/base
+promotion (promotion is a mirror with `force: true`).
+
+| Input | Required | Default | Description |
+| ----- | -------- | ------- | ----------- |
+| `source-image` | yes | — | Source image without tag. |
+| `source-tag` | yes | — | Source tag. |
+| `dest-image` | yes | — | Destination image without tag. |
+| `dest-tag` | yes | — | Destination tag. |
+| `force` | no | `false` | Copy even when digests match. |
+| `copy-referrers` | no | `false` | Use `oras cp -r` to carry referrers (SBOM/provenance/VEX/signatures). |
+
+Outputs: `copied`, `digest`, `previous-digest`, `referrers-note`.
+
+### scan-image
+
+Scan one image filesystem with `trivy image`.
+
+| Input | Required | Default | Description |
+| ----- | -------- | ------- | ----------- |
+| `image-ref` | yes | — | Image reference to scan (`repo:tag`). |
+| `severities` | yes | — | Comma-separated severities (e.g. `HIGH,CRITICAL`). |
+| `output-dir` | yes | — | Directory for `report.json` and `blocking-ids.txt`. |
+
+Outputs: `report-path`, `blocking-ids-path`.
+
+### scan-sbom
+
+Scan one image's per-platform SBOM attestations with `trivy sbom`.
+
+| Input | Required | Default | Description |
+| ----- | -------- | ------- | ----------- |
+| `image-ref` | yes | — | Image reference to scan (`repo:tag`). |
+| `repository` | yes | — | Repository the image lives in (for referrer fetch). |
+| `severities` | yes | — | Comma-separated severities. |
+| `sbom-predicate-type` | yes | — | in-toto predicate type of the SBOM to scan. |
+| `exceptions-file` | yes | — | Sorted file of excepted CVE IDs (per-platform breakdown only). |
+| `output-dir` | yes | — | Directory for SBOMs, reports, and the blocking-ids list. |
+
+Outputs: `blocking-ids-path`, `missing-sbom-count`, `platform-count`,
+`platform-detail-path`.
+
+### evaluate-findings
+
+Apply the gate (threshold + exceptions) to one image's findings.
+
+| Input | Required | Default | Description |
+| ----- | -------- | ------- | ----------- |
+| `blocking-ids-file` | yes | — | Vulnerability IDs the scanner reported. |
+| `exceptions-file` | yes | — | Sorted, de-duplicated excepted CVE IDs (may be empty). |
+| `dry-run` | no | `false` | A passing image yields `dryrun` instead of `promote`. |
+| `missing-sbom-count` | no | `0` | Non-zero forces `blocked-missing-sbom`. |
+| `output-dir` | yes | — | Directory for the computed gate files. |
+
+Outputs: `decision`, `blocking-count`, `remaining-count`, `excepted-count`,
+`excepted-str`, `remaining-md`, `excepted-md`.
+
+### attach-scan-report
+
+Attach an empty OCI scan-report referrer to a promoted image.
+
+| Input | Required | Default | Description |
+| ----- | -------- | ------- | ----------- |
+| `image-ref` | yes | — | Promoted image to attach to (`repo:tag`). |
+| `source-repo` | yes | — | Repository the image was promoted from. |
+| `tag` | yes | — | Tag that was scanned and promoted. |
+| `threshold` | yes | — | Severity threshold the image passed. |
+| `excepted-str` | no | `""` | Pipe-separated excepted CVEs. |
+| `scanner-version` | yes | — | Resolved Trivy version. |
+| `method` | no | `image` | Scan method recorded: `image` or `sbom`. |
+| `sbom-predicate-type` | no | `""` | Recorded only when `method` is `sbom`. |
+
+The referrer artifact type is `application/vnd.cssc.scan-report.v1+json`; see the
+[scan-and-promote architecture](../architecture/workflows/scan-and-promote-workflows.md#scan-report-referrer-artifact)
+for the full annotation schema.
+
+### delete-image
+
+Delete one tag from a GHCR repository via the Packages REST API.
+
+| Input | Required | Default | Description |
+| ----- | -------- | ------- | ----------- |
+| `repository` | yes | — | GHCR repository, without tag. |
+| `tag` | yes | — | Tag to delete. |
+| `token` | no | `""` | PAT with `delete:packages`; deletion is skipped when empty. |
+
+Outputs: `status` (`deleted` / `skipped` / `failed`).
+
+## How the actions compose
+
+### Mirror workflow (`_mirror-image.yml`)
+
+A single job: check out, set up `crane` (and `oras` when copying referrers), run
+**registry-login** for the source (when authenticated) and GHCR, then
+**mirror-image**, then write a summary from its outputs.
+
+### Scan workflows (`_scan-image.yml`, `_scan-sbom-image.yml`)
+
+A matrix fan-out across three jobs:
+
+```text
+enumerate ──► scan (matrix: one job per tag) ──► summary
+   │             │                                  │
+   │             ├─ registry-login                  └─ aggregate per-tag
+   ├─ registry-login    ├─ scan-image / scan-sbom      result artifacts into
+   ├─ resolve severities├─ evaluate-findings           one job summary
+   └─ enumerate-tags    ├─ mirror-image (promote)
+       → tags-json      ├─ attach-scan-report
+                        ├─ delete-image
+                        └─ upload result artifact
+```
+
+- **enumerate** lists the tags (`enumerate-tags`) and resolves the severity set,
+  emitting a JSON tag array consumed by `strategy.matrix`.
+- **scan** runs once per tag, in parallel (`fail-fast: false`), chaining the
+  single-image actions and uploading a small result artifact.
+- **summary** downloads every result artifact and renders one aggregated job
+  summary (overview table + per-image detail), so the output matches the old
+  monolithic workflow despite the parallel topology.


### PR DESCRIPTION
## Summary

Refactors the GitHub Actions into small, single-purpose **composite actions** under `.github/actions/` and standardizes the terminology, so the steps (login, enumerate, copy, scan, gate, attach, delete) can be reused to compose more complex workflows.

### Composite actions
- `registry-login` — crane (+ optional oras) login
- `enumerate-tags` — `crane ls` → JSON array for matrix fan-out
- `mirror-image` — digest-compare + `crane copy` / `oras cp -r` (referrers folded in; promotion = `force: true`)
- `scan-image` — `trivy image`
- `scan-sbom` — per-platform SBOM extract + `trivy sbom`
- `evaluate-findings` — threshold + CVE-exception gate → decision
- `attach-scan-report` — `oras attach` scan-report referrer
- `delete-image` — GHCR package-version delete

### Workflows
- `_mirror-image.yml` now orchestrates `registry-login` + `mirror-image`.
- `_scan-image.yml` / `_scan-sbom-image.yml` fan out across a job matrix: **enumerate → scan (one job per tag) → summary**.
- Caller workflows (`mirror-*.yml`, `scan-*.yml`) are **unchanged** — `workflow_call` signatures are identical.

### Docs
- New canonical `docs/reference/workflow-actions.md` (action catalogue + terminology glossary).
- Updated naming, image-mirror, and scan-and-promote architecture docs.

### Validation
- VS Code problem checker clean on all files.
- `shellcheck -S warning` clean on every embedded `run` block.

## Notes
- Scan workflows now run **one job per tag** (parallel) instead of one looping job — same aggregated summary, different Actions UI topology.