### PR TITLE
Bump Node 20 actions to Node 24-compatible v5.0.0

### DIFF
--- a/.github/workflows/_mirror-image.yml
+++ b/.github/workflows/_mirror-image.yml
@@ -63,7 +63,7 @@ jobs:
       packages: write
     steps:
       - name: Check out actions
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
 
       - name: Set up crane
         uses: imjasonh/setup-crane@31b88efe9de28ae0ffa220711af4b60be9435f6e # v0.4

--- a/.github/workflows/_scan-image.yml
+++ b/.github/workflows/_scan-image.yml
@@ -78,7 +78,7 @@ jobs:
       severities: ${{ steps.config.outputs.severities }}
     steps:
       - name: Check out actions
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
 
       - name: Set up crane
         uses: imjasonh/setup-crane@31b88efe9de28ae0ffa220711af4b60be9435f6e # v0.4
@@ -148,7 +148,7 @@ jobs:
       TRIVY_PASSWORD: "${{ github.token }}"
     steps:
       - name: Check out actions
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
 
       - name: Set up crane
         uses: imjasonh/setup-crane@31b88efe9de28ae0ffa220711af4b60be9435f6e # v0.4
@@ -381,7 +381,7 @@ jobs:
 
       - name: Upload result
         if: always()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
         with:
           name: scan-result-${{ strategy.job-index }}
           path: ${{ runner.temp }}/result
@@ -394,7 +394,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Download results
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0.0
         with:
           pattern: scan-result-*
           path: ${{ runner.temp }}/results

--- a/.github/workflows/_scan-sbom-image.yml
+++ b/.github/workflows/_scan-sbom-image.yml
@@ -82,7 +82,7 @@ jobs:
       severities: ${{ steps.config.outputs.severities }}
     steps:
       - name: Check out actions
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
 
       - name: Set up crane
         uses: imjasonh/setup-crane@31b88efe9de28ae0ffa220711af4b60be9435f6e # v0.4
@@ -151,7 +151,7 @@ jobs:
       DRY_RUN: "${{ inputs.dry_run }}"
     steps:
       - name: Check out actions
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
 
       - name: Set up crane
         uses: imjasonh/setup-crane@31b88efe9de28ae0ffa220711af4b60be9435f6e # v0.4
@@ -358,7 +358,7 @@ jobs:
 
       - name: Upload result
         if: always()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
         with:
           name: scan-result-${{ strategy.job-index }}
           path: ${{ runner.temp }}/result
@@ -371,7 +371,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Download results
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0.0
         with:
           pattern: scan-result-*
           path: ${{ runner.temp }}/results


### PR DESCRIPTION
## Summary
GitHub deprecated Node.js 20 actions and will force them onto Node.js 24 by default on **2026-06-16**. This updates the pinned action SHAs in the reusable workflows to their Node 24-compatible `v5.0.0` releases, resolving the runner warning:

> Warning: Node.js 20 actions are deprecated. The following actions are running on Node.js 20 ... actions/checkout, actions/upload-artifact.

## Changes
| Action | Old (Node 20) | New (Node 24) |
| --- | --- | --- |
| `actions/checkout` | v4.2.2 | v5.0.0 (`08c6903`) |
| `actions/upload-artifact` | v4.6.2 | v5.0.0 (`330a01c`) |
| `actions/download-artifact` | v4.3.0 | v5.0.0 (`634f93c`) |

Applied across `_mirror-image.yml`, `_scan-image.yml`, and `_scan-sbom-image.yml`.

## Notes
- The warning only named `checkout` and `upload-artifact` (the jobs that ran), but `download-artifact` had the same Node 20 runtime, so it was upgraded too.
- `download-artifact` v5 has one breaking change (single-artifact-by-ID output path). Our usage downloads by `pattern: scan-result-*` with `merge-multiple`, so it is unaffected.
- All SHAs verified against the upstream release tags.