### PR TITLE
Bump artifact actions to Node 24 and rename scan workflows to promote-from-quarantine

### DIFF
--- a/.github/workflows/_promote-from-quarantine-sbom.yml
+++ b/.github/workflows/_promote-from-quarantine-sbom.yml
@@ -1,36 +1,35 @@
-# Reusable workflow: scan a quarantined repository and promote clean images.
+# Reusable workflow: scan a quarantined image via its SBOM attestation and
+# promote clean images.
 #
 # This workflow is internal (note the leading underscore in the filename) and is
-# not meant to be triggered directly. It is called by per-image "scan-*"
-# workflows via `uses:`.
+# not meant to be triggered directly. It is called by per-image
+# "promote-from-quarantine-*" workflows via `uses:`.
+#
+# Unlike _promote-from-quarantine.yml (which runs `trivy image` against the image filesystem),
+# this workflow is built for distroless / hardened images such as Docker
+# Hardened Images (DHI), which contain no package-manager metadata. Instead it
+# scans the SBOM attestation that the mirror copied alongside the image.
 #
 # It orchestrates the shared composite actions under .github/actions/ and fans
-# the work out across a job matrix: an "enumerate" job lists the quarantine tags
-# (enumerate-tags) and a "scan" job runs once per tag, in parallel, performing
-# scan-image -> evaluate-findings -> mirror-image (promote) -> attach-scan-report
-# -> delete-image. A final "summary" job aggregates the per-tag results.
-#
-# For every tag in `source_repo` it:
-#   1. scans the image with Trivy (scan-image),
-#   2. applies a severity threshold plus an optional CVE exception list
-#      (evaluate-findings),
-#   3. promotes passing images into `dest_repo` (mirror-image, force),
-#   4. attaches an OCI scan-report referrer (attach-scan-report), and
-#   5. deletes the promoted tag from quarantine (delete-image).
+# the work out across a job matrix: an "enumerate" job lists the quarantine image
+# tags (enumerate-tags) and a "scan" job runs once per tag, in parallel,
+# performing scan-sbom -> evaluate-findings -> mirror-image (promote, with
+# referrers) -> attach-scan-report -> delete-image. A final "summary" job
+# aggregates the per-tag results.
 #
 # Terminology and the action catalogue: see docs/reference/workflow-actions.md.
-# See also docs/architecture/workflows/scan-and-promote-workflows.md.
-name: _reusable / scan-image
+# See also docs/architecture/workflows/promote-from-quarantine-workflows.md.
+name: _reusable / promote-from-quarantine-sbom
 
 on:
   workflow_call:
     inputs:
       source_repo:
-        description: "Quarantine repository to scan, without tag (e.g. ghcr.io/toddysm/quarantine/python)."
+        description: "Quarantine repository to scan, without tag (e.g. ghcr.io/toddysm/quarantine/hardened/python)."
         required: true
         type: string
       dest_repo:
-        description: "Promotion-target repository, without tag (e.g. ghcr.io/toddysm/golden/python)."
+        description: "Promotion-target repository, without tag (e.g. ghcr.io/toddysm/base/hardened/python)."
         required: true
         type: string
       severity_threshold:
@@ -42,6 +41,11 @@ on:
         description: "Pipe-separated allow-list of CVE IDs (e.g. CVE-2024-1234|CVE-2024-5678)."
         required: false
         default: ""
+        type: string
+      sbom_predicate_type:
+        description: "in-toto predicate type of the SBOM attestation to scan (e.g. https://cyclonedx.org/bom/v1.6 or https://spdx.dev/Document)."
+        required: false
+        default: https://cyclonedx.org/bom/v1.6
         type: string
       delete_source:
         description: "Delete the tag from quarantine after a successful promotion."
@@ -64,9 +68,9 @@ on:
         required: false
 
 jobs:
-  # --- Phase 1: list the quarantine tags and resolve the severity set. --------
-  # Distinguishes an empty / not-yet-created repository (expected, has_tags
-  # false) from a real failure such as an auth or transient registry error.
+  # --- Phase 1: list the quarantine image tags and resolve the severity set. ---
+  # Drops sha256-* referrer fallback tags. Distinguishes an empty repository
+  # (expected, has_tags false) from a real failure.
   enumerate:
     runs-on: ubuntu-latest
     permissions:
@@ -105,11 +109,12 @@ jobs:
           esac
           echo "severities=${severities}" >> "${GITHUB_OUTPUT}"
 
-      - name: Enumerate quarantine tags
+      - name: Enumerate quarantine image tags
         id: enumerate
         uses: ./.github/actions/enumerate-tags
         with:
           repository: ${{ inputs.source_repo }}
+          exclude-referrer-tags: "true"
 
       - name: Note empty repository
         if: steps.enumerate.outputs.has-tags != 'true'
@@ -119,12 +124,12 @@ jobs:
         run: |
           set -euo pipefail
           {
-            echo "### Scan & promote: \`${SOURCE_REPO}\` → \`${DEST_REPO}\`"
+            echo "### SBOM scan & promote: \`${SOURCE_REPO}\` → \`${DEST_REPO}\`"
             echo ""
-            echo "No tags found in the source repository; nothing to do."
+            echo "No image tags found in the source repository; nothing to do."
           } >> "${GITHUB_STEP_SUMMARY}"
 
-  # --- Phase 2: scan, gate, promote, attest, and clean up — one job per tag. ---
+  # --- Phase 2: scan SBOMs, gate, promote, attest, and clean up — per tag. -----
   scan:
     needs: enumerate
     if: needs.enumerate.outputs.has-tags == 'true'
@@ -141,11 +146,9 @@ jobs:
       DEST_REPO: "${{ inputs.dest_repo }}"
       THRESHOLD: "${{ inputs.severity_threshold }}"
       SEVERITIES: "${{ needs.enumerate.outputs.severities }}"
+      SBOM_PREDICATE_TYPE: "${{ inputs.sbom_predicate_type }}"
       TAG: "${{ matrix.tag }}"
       DRY_RUN: "${{ inputs.dry_run }}"
-      # Authenticate Trivy's remote image pulls to GHCR.
-      TRIVY_USERNAME: "${{ github.actor }}"
-      TRIVY_PASSWORD: "${{ github.token }}"
     steps:
       - name: Check out actions
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
@@ -171,8 +174,6 @@ jobs:
           password: ${{ github.token }}
           with-oras: "true"
 
-      # Normalise the exception list and resolve the actual Trivy version for the
-      # referrer annotation; both feed the per-tag actions below.
       - name: Prepare gate inputs
         id: prepare
         env:
@@ -192,7 +193,6 @@ jobs:
             printf '%s\n' "${EXCEPTIONS}" | tr '|' '\n' | sed '/^[[:space:]]*$/d' \
               | tr -d '[:space:]' | sort -u > "${exceptions_file}"
           fi
-          echo "EXCEPTIONS_FILE=${exceptions_file}" >> "${GITHUB_ENV}"
           echo "exceptions-file=${exceptions_file}" >> "${GITHUB_OUTPUT}"
 
           trivy_resolved="$(trivy version -f json 2>/dev/null | jq -r '.Version // empty' || true)"
@@ -200,12 +200,15 @@ jobs:
           echo "TRIVY_RESOLVED=${trivy_resolved}" >> "${GITHUB_ENV}"
           echo "trivy-resolved=${trivy_resolved}" >> "${GITHUB_OUTPUT}"
 
-      - name: Scan image
+      - name: Scan SBOMs
         id: scan
-        uses: ./.github/actions/scan-image
+        uses: ./.github/actions/scan-sbom
         with:
           image-ref: ${{ inputs.source_repo }}:${{ matrix.tag }}
+          repository: ${{ inputs.source_repo }}
           severities: ${{ needs.enumerate.outputs.severities }}
+          sbom-predicate-type: ${{ inputs.sbom_predicate_type }}
+          exceptions-file: ${{ steps.prepare.outputs.exceptions-file }}
           output-dir: ${{ runner.temp }}/cssc-scan/state
 
       - name: Evaluate findings
@@ -215,6 +218,7 @@ jobs:
           blocking-ids-file: ${{ steps.scan.outputs.blocking-ids-path }}
           exceptions-file: ${{ steps.prepare.outputs.exceptions-file }}
           dry-run: ${{ inputs.dry_run }}
+          missing-sbom-count: ${{ steps.scan.outputs.missing-sbom-count }}
           output-dir: ${{ runner.temp }}/cssc-scan/state
 
       - name: Promote passing image
@@ -227,6 +231,7 @@ jobs:
           dest-image: ${{ inputs.dest_repo }}
           dest-tag: ${{ matrix.tag }}
           force: "true"
+          copy-referrers: "true"
 
       - name: Attach scan-report attestation
         if: steps.evaluate.outputs.decision == 'promote'
@@ -238,7 +243,8 @@ jobs:
           threshold: ${{ inputs.severity_threshold }}
           excepted-str: ${{ steps.evaluate.outputs.excepted-str }}
           scanner-version: ${{ steps.prepare.outputs.trivy-resolved }}
-          method: image
+          method: sbom
+          sbom-predicate-type: ${{ inputs.sbom_predicate_type }}
 
       - name: Delete promoted tag from quarantine
         id: delete
@@ -249,9 +255,6 @@ jobs:
           tag: ${{ matrix.tag }}
           token: ${{ secrets.ghcr_delete_token }}
 
-      # Render this tag's run log + result fragment and upload it for the summary
-      # job to aggregate. Runs even if an earlier step failed so partial results
-      # are still reported.
       - name: Record result
         if: always()
         env:
@@ -261,7 +264,9 @@ jobs:
           EXCEPTED_COUNT: "${{ steps.evaluate.outputs.excepted-count }}"
           REMAINING_MD: "${{ steps.evaluate.outputs.remaining-md }}"
           EXCEPTED_MD: "${{ steps.evaluate.outputs.excepted-md }}"
-          REPORT_PATH: "${{ steps.scan.outputs.report-path }}"
+          PLATFORM_COUNT: "${{ steps.scan.outputs.platform-count }}"
+          MISSING_SBOM: "${{ steps.scan.outputs.missing-sbom-count }}"
+          PLATFORM_DETAIL_PATH: "${{ steps.scan.outputs.platform-detail-path }}"
           DEL_STATUS: "${{ steps.delete.outputs.status }}"
         run: |
           set -euo pipefail
@@ -279,6 +284,8 @@ jobs:
           excepted_count="${EXCEPTED_COUNT:-0}"
           remaining_md="${REMAINING_MD:-}"
           excepted_md="${EXCEPTED_MD:-}"
+          platform_count="${PLATFORM_COUNT:-0}"
+          missing_sbom="${MISSING_SBOM:-0}"
 
           # Map delete-image's raw status to user-facing wording for the report.
           case "${DEL_STATUS:-}" in
@@ -289,6 +296,9 @@ jobs:
           esac
 
           case "${decision}" in
+            blocked-missing-sbom)
+              result_class="blocked"; result="blocked (missing SBOM)"; icon=":no_entry:"
+              promoted_yesno="no (left in quarantine)" ;;
             blocked)
               result_class="blocked"; result="blocked"; icon=":no_entry:"
               promoted_yesno="no (left in quarantine)" ;;
@@ -307,73 +317,40 @@ jobs:
           printf '%s' "${result_class}" > "${out}/result_class"
           printf '%s' "${TRIVY_RESOLVED:-}" > "${out}/scanner"
 
-          # Per-CVE detail (id, severity, package, installed, fixed) from the report.
-          vulns_tsv="${out}/vulns.tsv"
-          : > "${vulns_tsv}"
-          if [ -n "${REPORT_PATH}" ] && [ -s "${REPORT_PATH}" ]; then
-            jq -r '
-              [ .Results[]? | (.Vulnerabilities[]? | {
-                  id: .VulnerabilityID,
-                  sev: (.Severity // "UNKNOWN"),
-                  pkg: (.PkgName // ""),
-                  installed: (.InstalledVersion // ""),
-                  fixed: (.FixedVersion // "")
-                }) ]
-              | unique_by("\(.id)|\(.pkg)|\(.installed)")
-              | map(. + {rank: ({"CRITICAL":0,"HIGH":1,"MEDIUM":2,"LOW":3}[.sev] // 9)})
-              | sort_by(.rank, .id)
-              | .[] | [.id, .sev, .pkg, .installed, .fixed] | @tsv
-            ' "${REPORT_PATH}" > "${vulns_tsv}" || true
-          fi
-
           # --- Human-readable report to the run log. ---------------------------
           {
             echo "================================================================"
             echo "Image:            ${src}"
             echo "Result:           ${result}"
             echo "Promoted:         ${promoted_yesno}"
+            echo "SBOM predicate:   ${SBOM_PREDICATE_TYPE}"
+            echo "Platforms:        ${platform_count} (missing SBOM: ${missing_sbom})"
             echo "Threshold:        ${THRESHOLD} (severities: ${SEVERITIES})"
             echo "CVEs ≥ ${THRESHOLD}:   ${blocking_count} (blocking: ${remaining_count}, excepted: ${excepted_count})"
-            if [ -s "${vulns_tsv}" ]; then
-              printf '  %-22s %-9s %-28s %-18s %s\n' "CVE" "SEVERITY" "PACKAGE" "INSTALLED" "STATUS"
-              while IFS="$(printf '\t')" read -r id sev pkg installed fixed; do
-                if [ -s "${EXCEPTIONS_FILE}" ] && grep -qxF "${id}" "${EXCEPTIONS_FILE}"; then st="EXCEPTED"; else st="BLOCKING"; fi
-                printf '  %-22s %-9s %-28s %-18s %s\n' "${id}" "${sev}" "${pkg}" "${installed:-—}" "${st}"
-              done < "${vulns_tsv}"
-            else
-              echo "  (no vulnerabilities at or above the threshold)"
-            fi
           }
 
           # --- Summary table row. ----------------------------------------------
-          printf '| `%s` | %s %s | %s | %s | %s |\n' \
-            "${TAG}" "${icon}" "${result}" "${blocking_count}" \
+          printf '| `%s` | %s %s | %s | %s | %s | %s |\n' \
+            "${TAG}" "${icon}" "${result}" "${platform_count}" "${blocking_count}" \
             "${remaining_md:-—}" "${excepted_md:-—}" > "${out}/row.md"
 
           # --- Collapsible per-image detail for the job summary. ----------------
           {
             echo ""
-            echo "<details><summary><code>${TAG}</code> — ${icon} ${result} · ${blocking_count} CVE(s) ≥ ${THRESHOLD}</summary>"
+            echo "<details><summary><code>${TAG}</code> — ${icon} ${result} · ${blocking_count} CVE(s) ≥ ${THRESHOLD} across ${platform_count} platform(s)</summary>"
             echo ""
             echo "- **Source:** \`${src}\`"
             echo "- **Destination:** \`${dest}\`"
             echo "- **Promoted:** ${promoted_yesno}"
+            echo "- **SBOM predicate type:** \`${SBOM_PREDICATE_TYPE}\`"
             echo "- **Blocking (not excepted):** ${remaining_count} · **Excepted:** ${excepted_count}"
             echo ""
-            echo "| CVE | Severity | Package | Installed | Fixed | Status |"
-            echo "| --- | --- | --- | --- | --- | --- |"
-            if [ -s "${vulns_tsv}" ]; then
-              while IFS="$(printf '\t')" read -r id sev pkg installed fixed; do
-                if [ -s "${EXCEPTIONS_FILE}" ] && grep -qxF "${id}" "${EXCEPTIONS_FILE}"; then
-                  st=":large_yellow_circle: excepted"
-                else
-                  st=":red_circle: blocking"
-                fi
-                printf '| %s | %s | `%s` | %s | %s | %s |\n' \
-                  "${id}" "${sev}" "${pkg}" "${installed:-—}" "${fixed:-—}" "${st}"
-              done < "${vulns_tsv}"
+            echo "| Platform | CVEs ≥ ${THRESHOLD} | Blocking | Blocking CVE IDs |"
+            echo "| --- | --- | --- | --- |"
+            if [ -n "${PLATFORM_DETAIL_PATH}" ] && [ -s "${PLATFORM_DETAIL_PATH}" ]; then
+              cat "${PLATFORM_DETAIL_PATH}"
             else
-              echo "| — | — | — | — | — | none ≥ ${THRESHOLD} |"
+              echo "| — | — | — | (no platform detail recorded) |"
             fi
             echo ""
             echo "</details>"
@@ -381,7 +358,7 @@ jobs:
 
       - name: Upload result
         if: always()
-        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: scan-result-${{ strategy.job-index }}
           path: ${{ runner.temp }}/result
@@ -394,7 +371,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Download results
-        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0.0
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           pattern: scan-result-*
           path: ${{ runner.temp }}/results
@@ -406,6 +383,7 @@ jobs:
           DEST_REPO: "${{ inputs.dest_repo }}"
           THRESHOLD: "${{ inputs.severity_threshold }}"
           SEVERITIES: "${{ needs.enumerate.outputs.severities }}"
+          SBOM_PREDICATE_TYPE: "${{ inputs.sbom_predicate_type }}"
           DRY_RUN: "${{ inputs.dry_run }}"
         run: |
           set -euo pipefail
@@ -414,12 +392,12 @@ jobs:
           results="${RUNNER_TEMP}/results"
           promoted=0
           blocked=0
+          scanner=""
           rows="${RUNNER_TEMP}/rows.md"
           details_md="${RUNNER_TEMP}/details.md"
           : > "${rows}"
           : > "${details_md}"
 
-          scanner=""
           for d in "${results}"/*/; do
             [ -d "${d}" ] || continue
             [ -f "${d}/row.md" ] || continue
@@ -433,19 +411,19 @@ jobs:
           done
 
           {
-            echo "### Scan & promote: \`${SOURCE_REPO}\` → \`${DEST_REPO}\`"
+            echo "### SBOM scan & promote: \`${SOURCE_REPO}\` → \`${DEST_REPO}\`"
             echo ""
+            echo "- **Scan method:** SBOM (\`trivy sbom\`)"
+            echo "- **SBOM predicate type:** \`${SBOM_PREDICATE_TYPE}\`"
             echo "- **Threshold:** \`${THRESHOLD}\` (severities scanned: \`${SEVERITIES}\`)"
             if [ -n "${scanner}" ]; then echo "- **Scanner:** trivy \`${scanner}\`"; fi
             echo "- **Dry run:** \`${DRY_RUN}\`"
             echo "- **Promoted:** ${promoted} · **Blocked:** ${blocked}"
             echo ""
-            echo "| Tag | Result | CVEs ≥ ${THRESHOLD} | Blocking CVEs | Excepted |"
-            echo "| --- | ------ | --- | --- | --- |"
+            echo "| Tag | Result | Platforms | CVEs ≥ ${THRESHOLD} | Blocking CVEs | Excepted |"
+            echo "| --- | ------ | --- | --- | --- | --- |"
             cat "${rows}"
             echo ""
-            echo "#### Per-image vulnerability detail"
-            echo ""
-            echo "Status legend: :red_circle: blocking (counts against the threshold) · :large_yellow_circle: excepted (matched the exception list)."
+            echo "#### Per-image platform detail"
             cat "${details_md}"
           } >> "${GITHUB_STEP_SUMMARY}"

--- a/.github/workflows/_promote-from-quarantine.yml
+++ b/.github/workflows/_promote-from-quarantine.yml
@@ -1,35 +1,36 @@
-# Reusable workflow: scan a quarantined image via its SBOM attestation and
-# promote clean images.
+# Reusable workflow: scan a quarantined repository and promote clean images.
 #
 # This workflow is internal (note the leading underscore in the filename) and is
-# not meant to be triggered directly. It is called by per-image "scan-*"
-# workflows via `uses:`.
-#
-# Unlike _scan-image.yml (which runs `trivy image` against the image filesystem),
-# this workflow is built for distroless / hardened images such as Docker
-# Hardened Images (DHI), which contain no package-manager metadata. Instead it
-# scans the SBOM attestation that the mirror copied alongside the image.
+# not meant to be triggered directly. It is called by per-image
+# "promote-from-quarantine-*" workflows via `uses:`.
 #
 # It orchestrates the shared composite actions under .github/actions/ and fans
-# the work out across a job matrix: an "enumerate" job lists the quarantine image
-# tags (enumerate-tags) and a "scan" job runs once per tag, in parallel,
-# performing scan-sbom -> evaluate-findings -> mirror-image (promote, with
-# referrers) -> attach-scan-report -> delete-image. A final "summary" job
-# aggregates the per-tag results.
+# the work out across a job matrix: an "enumerate" job lists the quarantine tags
+# (enumerate-tags) and a "scan" job runs once per tag, in parallel, performing
+# scan-image -> evaluate-findings -> mirror-image (promote) -> attach-scan-report
+# -> delete-image. A final "summary" job aggregates the per-tag results.
+#
+# For every tag in `source_repo` it:
+#   1. scans the image with Trivy (scan-image),
+#   2. applies a severity threshold plus an optional CVE exception list
+#      (evaluate-findings),
+#   3. promotes passing images into `dest_repo` (mirror-image, force),
+#   4. attaches an OCI scan-report referrer (attach-scan-report), and
+#   5. deletes the promoted tag from quarantine (delete-image).
 #
 # Terminology and the action catalogue: see docs/reference/workflow-actions.md.
-# See also docs/architecture/workflows/scan-and-promote-workflows.md.
-name: _reusable / scan-sbom-image
+# See also docs/architecture/workflows/promote-from-quarantine-workflows.md.
+name: _reusable / promote-from-quarantine
 
 on:
   workflow_call:
     inputs:
       source_repo:
-        description: "Quarantine repository to scan, without tag (e.g. ghcr.io/toddysm/quarantine/hardened/python)."
+        description: "Quarantine repository to scan, without tag (e.g. ghcr.io/toddysm/quarantine/python)."
         required: true
         type: string
       dest_repo:
-        description: "Promotion-target repository, without tag (e.g. ghcr.io/toddysm/base/hardened/python)."
+        description: "Promotion-target repository, without tag (e.g. ghcr.io/toddysm/golden/python)."
         required: true
         type: string
       severity_threshold:
@@ -41,11 +42,6 @@ on:
         description: "Pipe-separated allow-list of CVE IDs (e.g. CVE-2024-1234|CVE-2024-5678)."
         required: false
         default: ""
-        type: string
-      sbom_predicate_type:
-        description: "in-toto predicate type of the SBOM attestation to scan (e.g. https://cyclonedx.org/bom/v1.6 or https://spdx.dev/Document)."
-        required: false
-        default: https://cyclonedx.org/bom/v1.6
         type: string
       delete_source:
         description: "Delete the tag from quarantine after a successful promotion."
@@ -68,9 +64,9 @@ on:
         required: false
 
 jobs:
-  # --- Phase 1: list the quarantine image tags and resolve the severity set. ---
-  # Drops sha256-* referrer fallback tags. Distinguishes an empty repository
-  # (expected, has_tags false) from a real failure.
+  # --- Phase 1: list the quarantine tags and resolve the severity set. --------
+  # Distinguishes an empty / not-yet-created repository (expected, has_tags
+  # false) from a real failure such as an auth or transient registry error.
   enumerate:
     runs-on: ubuntu-latest
     permissions:
@@ -109,12 +105,11 @@ jobs:
           esac
           echo "severities=${severities}" >> "${GITHUB_OUTPUT}"
 
-      - name: Enumerate quarantine image tags
+      - name: Enumerate quarantine tags
         id: enumerate
         uses: ./.github/actions/enumerate-tags
         with:
           repository: ${{ inputs.source_repo }}
-          exclude-referrer-tags: "true"
 
       - name: Note empty repository
         if: steps.enumerate.outputs.has-tags != 'true'
@@ -124,12 +119,12 @@ jobs:
         run: |
           set -euo pipefail
           {
-            echo "### SBOM scan & promote: \`${SOURCE_REPO}\` → \`${DEST_REPO}\`"
+            echo "### Scan & promote: \`${SOURCE_REPO}\` → \`${DEST_REPO}\`"
             echo ""
-            echo "No image tags found in the source repository; nothing to do."
+            echo "No tags found in the source repository; nothing to do."
           } >> "${GITHUB_STEP_SUMMARY}"
 
-  # --- Phase 2: scan SBOMs, gate, promote, attest, and clean up — per tag. -----
+  # --- Phase 2: scan, gate, promote, attest, and clean up — one job per tag. ---
   scan:
     needs: enumerate
     if: needs.enumerate.outputs.has-tags == 'true'
@@ -146,9 +141,11 @@ jobs:
       DEST_REPO: "${{ inputs.dest_repo }}"
       THRESHOLD: "${{ inputs.severity_threshold }}"
       SEVERITIES: "${{ needs.enumerate.outputs.severities }}"
-      SBOM_PREDICATE_TYPE: "${{ inputs.sbom_predicate_type }}"
       TAG: "${{ matrix.tag }}"
       DRY_RUN: "${{ inputs.dry_run }}"
+      # Authenticate Trivy's remote image pulls to GHCR.
+      TRIVY_USERNAME: "${{ github.actor }}"
+      TRIVY_PASSWORD: "${{ github.token }}"
     steps:
       - name: Check out actions
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
@@ -174,6 +171,8 @@ jobs:
           password: ${{ github.token }}
           with-oras: "true"
 
+      # Normalise the exception list and resolve the actual Trivy version for the
+      # referrer annotation; both feed the per-tag actions below.
       - name: Prepare gate inputs
         id: prepare
         env:
@@ -193,6 +192,7 @@ jobs:
             printf '%s\n' "${EXCEPTIONS}" | tr '|' '\n' | sed '/^[[:space:]]*$/d' \
               | tr -d '[:space:]' | sort -u > "${exceptions_file}"
           fi
+          echo "EXCEPTIONS_FILE=${exceptions_file}" >> "${GITHUB_ENV}"
           echo "exceptions-file=${exceptions_file}" >> "${GITHUB_OUTPUT}"
 
           trivy_resolved="$(trivy version -f json 2>/dev/null | jq -r '.Version // empty' || true)"
@@ -200,15 +200,12 @@ jobs:
           echo "TRIVY_RESOLVED=${trivy_resolved}" >> "${GITHUB_ENV}"
           echo "trivy-resolved=${trivy_resolved}" >> "${GITHUB_OUTPUT}"
 
-      - name: Scan SBOMs
+      - name: Scan image
         id: scan
-        uses: ./.github/actions/scan-sbom
+        uses: ./.github/actions/scan-image
         with:
           image-ref: ${{ inputs.source_repo }}:${{ matrix.tag }}
-          repository: ${{ inputs.source_repo }}
           severities: ${{ needs.enumerate.outputs.severities }}
-          sbom-predicate-type: ${{ inputs.sbom_predicate_type }}
-          exceptions-file: ${{ steps.prepare.outputs.exceptions-file }}
           output-dir: ${{ runner.temp }}/cssc-scan/state
 
       - name: Evaluate findings
@@ -218,7 +215,6 @@ jobs:
           blocking-ids-file: ${{ steps.scan.outputs.blocking-ids-path }}
           exceptions-file: ${{ steps.prepare.outputs.exceptions-file }}
           dry-run: ${{ inputs.dry_run }}
-          missing-sbom-count: ${{ steps.scan.outputs.missing-sbom-count }}
           output-dir: ${{ runner.temp }}/cssc-scan/state
 
       - name: Promote passing image
@@ -231,7 +227,6 @@ jobs:
           dest-image: ${{ inputs.dest_repo }}
           dest-tag: ${{ matrix.tag }}
           force: "true"
-          copy-referrers: "true"
 
       - name: Attach scan-report attestation
         if: steps.evaluate.outputs.decision == 'promote'
@@ -243,8 +238,7 @@ jobs:
           threshold: ${{ inputs.severity_threshold }}
           excepted-str: ${{ steps.evaluate.outputs.excepted-str }}
           scanner-version: ${{ steps.prepare.outputs.trivy-resolved }}
-          method: sbom
-          sbom-predicate-type: ${{ inputs.sbom_predicate_type }}
+          method: image
 
       - name: Delete promoted tag from quarantine
         id: delete
@@ -255,6 +249,9 @@ jobs:
           tag: ${{ matrix.tag }}
           token: ${{ secrets.ghcr_delete_token }}
 
+      # Render this tag's run log + result fragment and upload it for the summary
+      # job to aggregate. Runs even if an earlier step failed so partial results
+      # are still reported.
       - name: Record result
         if: always()
         env:
@@ -264,9 +261,7 @@ jobs:
           EXCEPTED_COUNT: "${{ steps.evaluate.outputs.excepted-count }}"
           REMAINING_MD: "${{ steps.evaluate.outputs.remaining-md }}"
           EXCEPTED_MD: "${{ steps.evaluate.outputs.excepted-md }}"
-          PLATFORM_COUNT: "${{ steps.scan.outputs.platform-count }}"
-          MISSING_SBOM: "${{ steps.scan.outputs.missing-sbom-count }}"
-          PLATFORM_DETAIL_PATH: "${{ steps.scan.outputs.platform-detail-path }}"
+          REPORT_PATH: "${{ steps.scan.outputs.report-path }}"
           DEL_STATUS: "${{ steps.delete.outputs.status }}"
         run: |
           set -euo pipefail
@@ -284,8 +279,6 @@ jobs:
           excepted_count="${EXCEPTED_COUNT:-0}"
           remaining_md="${REMAINING_MD:-}"
           excepted_md="${EXCEPTED_MD:-}"
-          platform_count="${PLATFORM_COUNT:-0}"
-          missing_sbom="${MISSING_SBOM:-0}"
 
           # Map delete-image's raw status to user-facing wording for the report.
           case "${DEL_STATUS:-}" in
@@ -296,9 +289,6 @@ jobs:
           esac
 
           case "${decision}" in
-            blocked-missing-sbom)
-              result_class="blocked"; result="blocked (missing SBOM)"; icon=":no_entry:"
-              promoted_yesno="no (left in quarantine)" ;;
             blocked)
               result_class="blocked"; result="blocked"; icon=":no_entry:"
               promoted_yesno="no (left in quarantine)" ;;
@@ -317,40 +307,73 @@ jobs:
           printf '%s' "${result_class}" > "${out}/result_class"
           printf '%s' "${TRIVY_RESOLVED:-}" > "${out}/scanner"
 
+          # Per-CVE detail (id, severity, package, installed, fixed) from the report.
+          vulns_tsv="${out}/vulns.tsv"
+          : > "${vulns_tsv}"
+          if [ -n "${REPORT_PATH}" ] && [ -s "${REPORT_PATH}" ]; then
+            jq -r '
+              [ .Results[]? | (.Vulnerabilities[]? | {
+                  id: .VulnerabilityID,
+                  sev: (.Severity // "UNKNOWN"),
+                  pkg: (.PkgName // ""),
+                  installed: (.InstalledVersion // ""),
+                  fixed: (.FixedVersion // "")
+                }) ]
+              | unique_by("\(.id)|\(.pkg)|\(.installed)")
+              | map(. + {rank: ({"CRITICAL":0,"HIGH":1,"MEDIUM":2,"LOW":3}[.sev] // 9)})
+              | sort_by(.rank, .id)
+              | .[] | [.id, .sev, .pkg, .installed, .fixed] | @tsv
+            ' "${REPORT_PATH}" > "${vulns_tsv}" || true
+          fi
+
           # --- Human-readable report to the run log. ---------------------------
           {
             echo "================================================================"
             echo "Image:            ${src}"
             echo "Result:           ${result}"
             echo "Promoted:         ${promoted_yesno}"
-            echo "SBOM predicate:   ${SBOM_PREDICATE_TYPE}"
-            echo "Platforms:        ${platform_count} (missing SBOM: ${missing_sbom})"
             echo "Threshold:        ${THRESHOLD} (severities: ${SEVERITIES})"
             echo "CVEs ≥ ${THRESHOLD}:   ${blocking_count} (blocking: ${remaining_count}, excepted: ${excepted_count})"
+            if [ -s "${vulns_tsv}" ]; then
+              printf '  %-22s %-9s %-28s %-18s %s\n' "CVE" "SEVERITY" "PACKAGE" "INSTALLED" "STATUS"
+              while IFS="$(printf '\t')" read -r id sev pkg installed fixed; do
+                if [ -s "${EXCEPTIONS_FILE}" ] && grep -qxF "${id}" "${EXCEPTIONS_FILE}"; then st="EXCEPTED"; else st="BLOCKING"; fi
+                printf '  %-22s %-9s %-28s %-18s %s\n' "${id}" "${sev}" "${pkg}" "${installed:-—}" "${st}"
+              done < "${vulns_tsv}"
+            else
+              echo "  (no vulnerabilities at or above the threshold)"
+            fi
           }
 
           # --- Summary table row. ----------------------------------------------
-          printf '| `%s` | %s %s | %s | %s | %s | %s |\n' \
-            "${TAG}" "${icon}" "${result}" "${platform_count}" "${blocking_count}" \
+          printf '| `%s` | %s %s | %s | %s | %s |\n' \
+            "${TAG}" "${icon}" "${result}" "${blocking_count}" \
             "${remaining_md:-—}" "${excepted_md:-—}" > "${out}/row.md"
 
           # --- Collapsible per-image detail for the job summary. ----------------
           {
             echo ""
-            echo "<details><summary><code>${TAG}</code> — ${icon} ${result} · ${blocking_count} CVE(s) ≥ ${THRESHOLD} across ${platform_count} platform(s)</summary>"
+            echo "<details><summary><code>${TAG}</code> — ${icon} ${result} · ${blocking_count} CVE(s) ≥ ${THRESHOLD}</summary>"
             echo ""
             echo "- **Source:** \`${src}\`"
             echo "- **Destination:** \`${dest}\`"
             echo "- **Promoted:** ${promoted_yesno}"
-            echo "- **SBOM predicate type:** \`${SBOM_PREDICATE_TYPE}\`"
             echo "- **Blocking (not excepted):** ${remaining_count} · **Excepted:** ${excepted_count}"
             echo ""
-            echo "| Platform | CVEs ≥ ${THRESHOLD} | Blocking | Blocking CVE IDs |"
-            echo "| --- | --- | --- | --- |"
-            if [ -n "${PLATFORM_DETAIL_PATH}" ] && [ -s "${PLATFORM_DETAIL_PATH}" ]; then
-              cat "${PLATFORM_DETAIL_PATH}"
+            echo "| CVE | Severity | Package | Installed | Fixed | Status |"
+            echo "| --- | --- | --- | --- | --- | --- |"
+            if [ -s "${vulns_tsv}" ]; then
+              while IFS="$(printf '\t')" read -r id sev pkg installed fixed; do
+                if [ -s "${EXCEPTIONS_FILE}" ] && grep -qxF "${id}" "${EXCEPTIONS_FILE}"; then
+                  st=":large_yellow_circle: excepted"
+                else
+                  st=":red_circle: blocking"
+                fi
+                printf '| %s | %s | `%s` | %s | %s | %s |\n' \
+                  "${id}" "${sev}" "${pkg}" "${installed:-—}" "${fixed:-—}" "${st}"
+              done < "${vulns_tsv}"
             else
-              echo "| — | — | — | (no platform detail recorded) |"
+              echo "| — | — | — | — | — | none ≥ ${THRESHOLD} |"
             fi
             echo ""
             echo "</details>"
@@ -358,7 +381,7 @@ jobs:
 
       - name: Upload result
         if: always()
-        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: scan-result-${{ strategy.job-index }}
           path: ${{ runner.temp }}/result
@@ -371,7 +394,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Download results
-        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0.0
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           pattern: scan-result-*
           path: ${{ runner.temp }}/results
@@ -383,7 +406,6 @@ jobs:
           DEST_REPO: "${{ inputs.dest_repo }}"
           THRESHOLD: "${{ inputs.severity_threshold }}"
           SEVERITIES: "${{ needs.enumerate.outputs.severities }}"
-          SBOM_PREDICATE_TYPE: "${{ inputs.sbom_predicate_type }}"
           DRY_RUN: "${{ inputs.dry_run }}"
         run: |
           set -euo pipefail
@@ -392,12 +414,12 @@ jobs:
           results="${RUNNER_TEMP}/results"
           promoted=0
           blocked=0
-          scanner=""
           rows="${RUNNER_TEMP}/rows.md"
           details_md="${RUNNER_TEMP}/details.md"
           : > "${rows}"
           : > "${details_md}"
 
+          scanner=""
           for d in "${results}"/*/; do
             [ -d "${d}" ] || continue
             [ -f "${d}/row.md" ] || continue
@@ -411,19 +433,19 @@ jobs:
           done
 
           {
-            echo "### SBOM scan & promote: \`${SOURCE_REPO}\` → \`${DEST_REPO}\`"
+            echo "### Scan & promote: \`${SOURCE_REPO}\` → \`${DEST_REPO}\`"
             echo ""
-            echo "- **Scan method:** SBOM (\`trivy sbom\`)"
-            echo "- **SBOM predicate type:** \`${SBOM_PREDICATE_TYPE}\`"
             echo "- **Threshold:** \`${THRESHOLD}\` (severities scanned: \`${SEVERITIES}\`)"
             if [ -n "${scanner}" ]; then echo "- **Scanner:** trivy \`${scanner}\`"; fi
             echo "- **Dry run:** \`${DRY_RUN}\`"
             echo "- **Promoted:** ${promoted} · **Blocked:** ${blocked}"
             echo ""
-            echo "| Tag | Result | Platforms | CVEs ≥ ${THRESHOLD} | Blocking CVEs | Excepted |"
-            echo "| --- | ------ | --- | --- | --- | --- |"
+            echo "| Tag | Result | CVEs ≥ ${THRESHOLD} | Blocking CVEs | Excepted |"
+            echo "| --- | ------ | --- | --- | --- |"
             cat "${rows}"
             echo ""
-            echo "#### Per-image platform detail"
+            echo "#### Per-image vulnerability detail"
+            echo ""
+            echo "Status legend: :red_circle: blocking (counts against the threshold) · :large_yellow_circle: excepted (matched the exception list)."
             cat "${details_md}"
           } >> "${GITHUB_STEP_SUMMARY}"

--- a/.github/workflows/promote-from-quarantine-hardened-python.yml
+++ b/.github/workflows/promote-from-quarantine-hardened-python.yml
@@ -3,7 +3,7 @@
 #
 # This caller only defines triggers and the repository-specific inputs; the
 # scan/gate/promote/attest/cleanup logic lives in the reusable
-# _scan-sbom-image.yml workflow. Hardened (DHI) images are distroless and carry
+# _promote-from-quarantine-sbom.yml workflow. Hardened (DHI) images are distroless and carry
 # no package-manager metadata, so they are scanned via the SBOM attestation that
 # the mirror copied into quarantine rather than with `trivy image`. The source
 # image already lives in GHCR, so no dhi.io/Docker Hub authentication is required
@@ -15,9 +15,10 @@
 # dedicated "base/hardened/<image>" namespace, so dest_repo intentionally does
 # NOT follow the golden/ convention.
 #
-# Naming convention: "scan-<image>.yml" for scan-and-promote workflows. See
+# Naming convention: "promote-from-quarantine-<image>.yml" for
+# promote-from-quarantine workflows. See
 # docs/contributing/workflow-naming.md.
-name: scan / quarantine/hardened/python
+name: promote from quarantine / quarantine/hardened/python
 
 on:
   # Daily scan at 07:00 UTC, after the 06:00 mirror has refreshed quarantine.
@@ -55,9 +56,9 @@ on:
         default: false
         type: boolean
 
-# Avoid overlapping runs for this specific scan.
+# Avoid overlapping runs for this specific promote-from-quarantine workflow.
 concurrency:
-  group: scan-quarantine-hardened-python
+  group: promote-from-quarantine-hardened-python
   cancel-in-progress: false
 
 permissions:
@@ -65,8 +66,8 @@ permissions:
   packages: write
 
 jobs:
-  scan-hardened-python:
-    uses: ./.github/workflows/_scan-sbom-image.yml
+  promote-from-quarantine-hardened-python:
+    uses: ./.github/workflows/_promote-from-quarantine-sbom.yml
     with:
       source_repo: ghcr.io/toddysm/quarantine/hardened/python
       dest_repo: ghcr.io/toddysm/base/hardened/python

--- a/.github/workflows/promote-from-quarantine-node.yml
+++ b/.github/workflows/promote-from-quarantine-node.yml
@@ -1,13 +1,14 @@
 # Scan quarantine/node with Trivy and promote clean images into base/node.
 #
 # This caller only defines triggers and the repository-specific inputs; the
-# scan/gate/promote/attest/cleanup logic lives in the reusable _scan-image.yml
-# workflow.
+# scan/gate/promote/attest/cleanup logic lives in the reusable
+# _promote-from-quarantine.yml workflow.
 #
-# Naming convention: "scan-<image>.yml" for scan-and-promote workflows, kept
-# separate from "mirror-<image>.yml" and "build-<app>.yml". See
+# Naming convention: "promote-from-quarantine-<image>.yml" for
+# promote-from-quarantine workflows, kept separate from "mirror-<image>.yml" and
+# "build-<app>.yml". See
 # docs/contributing/workflow-naming.md.
-name: scan / quarantine/node
+name: promote from quarantine / quarantine/node
 
 on:
   # Daily scan at 07:00 UTC, after the 06:00 mirror has refreshed quarantine.
@@ -37,9 +38,9 @@ on:
         default: false
         type: boolean
 
-# Avoid overlapping runs for this specific scan.
+# Avoid overlapping runs for this specific promote-from-quarantine workflow.
 concurrency:
-  group: scan-quarantine-node
+  group: promote-from-quarantine-node
   cancel-in-progress: false
 
 permissions:
@@ -47,8 +48,8 @@ permissions:
   packages: write
 
 jobs:
-  scan-node:
-    uses: ./.github/workflows/_scan-image.yml
+  promote-from-quarantine-node:
+    uses: ./.github/workflows/_promote-from-quarantine.yml
     with:
       source_repo: ghcr.io/toddysm/quarantine/node
       dest_repo: ghcr.io/toddysm/base/node

--- a/.github/workflows/promote-from-quarantine-openjdk.yml
+++ b/.github/workflows/promote-from-quarantine-openjdk.yml
@@ -1,13 +1,14 @@
 # Scan quarantine/openjdk with Trivy and promote clean images into golden/openjdk.
 #
 # This caller only defines triggers and the repository-specific inputs; the
-# scan/gate/promote/attest/cleanup logic lives in the reusable _scan-image.yml
-# workflow.
+# scan/gate/promote/attest/cleanup logic lives in the reusable
+# _promote-from-quarantine.yml workflow.
 #
-# Naming convention: "scan-<image>.yml" for scan-and-promote workflows, kept
-# separate from "mirror-<image>.yml" and "build-<app>.yml". See
+# Naming convention: "promote-from-quarantine-<image>.yml" for
+# promote-from-quarantine workflows, kept separate from "mirror-<image>.yml" and
+# "build-<app>.yml". See
 # docs/contributing/workflow-naming.md.
-name: scan / quarantine/openjdk
+name: promote from quarantine / quarantine/openjdk
 
 on:
   # Daily scan at 07:00 UTC, after the 06:00 mirror has refreshed quarantine.
@@ -37,9 +38,9 @@ on:
         default: false
         type: boolean
 
-# Avoid overlapping runs for this specific scan.
+# Avoid overlapping runs for this specific promote-from-quarantine workflow.
 concurrency:
-  group: scan-quarantine-openjdk
+  group: promote-from-quarantine-openjdk
   cancel-in-progress: false
 
 permissions:
@@ -47,8 +48,8 @@ permissions:
   packages: write
 
 jobs:
-  scan-openjdk:
-    uses: ./.github/workflows/_scan-image.yml
+  promote-from-quarantine-openjdk:
+    uses: ./.github/workflows/_promote-from-quarantine.yml
     with:
       source_repo: ghcr.io/toddysm/quarantine/openjdk
       dest_repo: ghcr.io/toddysm/golden/openjdk

--- a/.github/workflows/promote-from-quarantine-python.yml
+++ b/.github/workflows/promote-from-quarantine-python.yml
@@ -1,13 +1,14 @@
 # Scan quarantine/python with Trivy and promote clean images into golden/python.
 #
 # This caller only defines triggers and the repository-specific inputs; the
-# scan/gate/promote/attest/cleanup logic lives in the reusable _scan-image.yml
-# workflow.
+# scan/gate/promote/attest/cleanup logic lives in the reusable
+# _promote-from-quarantine.yml workflow.
 #
-# Naming convention: "scan-<image>.yml" for scan-and-promote workflows, kept
-# separate from "mirror-<image>.yml" and "build-<app>.yml". See
+# Naming convention: "promote-from-quarantine-<image>.yml" for
+# promote-from-quarantine workflows, kept separate from "mirror-<image>.yml" and
+# "build-<app>.yml". See
 # docs/contributing/workflow-naming.md.
-name: scan / quarantine/python
+name: promote from quarantine / quarantine/python
 
 on:
   # Daily scan at 07:00 UTC, after the 06:00 mirror has refreshed quarantine.
@@ -37,9 +38,9 @@ on:
         default: false
         type: boolean
 
-# Avoid overlapping runs for this specific scan.
+# Avoid overlapping runs for this specific promote-from-quarantine workflow.
 concurrency:
-  group: scan-quarantine-python
+  group: promote-from-quarantine-python
   cancel-in-progress: false
 
 permissions:
@@ -47,8 +48,8 @@ permissions:
   packages: write
 
 jobs:
-  scan-python:
-    uses: ./.github/workflows/_scan-image.yml
+  promote-from-quarantine-python:
+    uses: ./.github/workflows/_promote-from-quarantine.yml
     with:
       source_repo: ghcr.io/toddysm/quarantine/python
       dest_repo: ghcr.io/toddysm/golden/python

--- a/docs/architecture/workflows/README.md
+++ b/docs/architecture/workflows/README.md
@@ -8,7 +8,7 @@ Workflows fall into three categories (see
 | Category | Purpose | Status |
 | -------- | ------- | ------ |
 | **Mirror** | Copy / refresh upstream base images from Docker Hub into GHCR | Implemented |
-| **Promote from quarantine** | Scan quarantined images and promote the ones that pass a vulnerability policy into `golden/<image>` | Implemented |
+| **Promote from quarantine** | Scan quarantined images and promote the ones that pass a vulnerability policy into `golden/<image>` (or `base/...` for base/hardened images) | Implemented |
 | **Build** | Build the demo applications under `apps/` on top of mirrored bases | Planned |
 
 ## Documents
@@ -18,5 +18,6 @@ Workflows fall into three categories (see
   and deliberately do not do.
 - [Promote-from-quarantine workflows](promote-from-quarantine-workflows.md) — how quarantined
   images are scanned with Trivy, gated on a severity threshold plus CVE
-  exceptions, promoted into `golden/<image>` with a scan-report referrer, and
+  exceptions, promoted into `golden/<image>` (or `base/...` for base/hardened
+  images) with a scan-report referrer, and
   removed from quarantine.

--- a/docs/architecture/workflows/README.md
+++ b/docs/architecture/workflows/README.md
@@ -8,7 +8,7 @@ Workflows fall into three categories (see
 | Category | Purpose | Status |
 | -------- | ------- | ------ |
 | **Mirror** | Copy / refresh upstream base images from Docker Hub into GHCR | Implemented |
-| **Scan** | Scan quarantined images and promote the ones that pass a vulnerability policy into `golden/<image>` | Implemented |
+| **Promote from quarantine** | Scan quarantined images and promote the ones that pass a vulnerability policy into `golden/<image>` | Implemented |
 | **Build** | Build the demo applications under `apps/` on top of mirrored bases | Planned |
 
 ## Documents
@@ -16,7 +16,7 @@ Workflows fall into three categories (see
 - [Image mirror workflows](image-mirror-workflows.md) — how the Docker Hub →
   GHCR mirroring actions are structured, the tooling they use, and what they do
   and deliberately do not do.
-- [Scan-and-promote workflows](scan-and-promote-workflows.md) — how quarantined
+- [Promote-from-quarantine workflows](promote-from-quarantine-workflows.md) — how quarantined
   images are scanned with Trivy, gated on a severity threshold plus CVE
   exceptions, promoted into `golden/<image>` with a scan-report referrer, and
   removed from quarantine.

--- a/docs/architecture/workflows/promote-from-quarantine-workflows.md
+++ b/docs/architecture/workflows/promote-from-quarantine-workflows.md
@@ -1,4 +1,4 @@
-# Scan-and-promote workflows architecture
+# Promote-from-quarantine workflows architecture
 
 This document describes the architecture of the GitHub Actions workflows that
 scan the container images sitting in a `quarantine/<image>` repository and
@@ -18,7 +18,8 @@ mirror workflows that populate quarantine in the first place, see
 
 The mirror workflows keep a private copy of upstream base images fresh inside
 `quarantine/<image>`. Quarantine is intentionally *untrusted*: an image landing
-there has only been copied, never inspected. The scan-and-promote workflows add
+there has only been copied, never inspected. The promote-from-quarantine
+workflows add
 the missing gate. They:
 
 - enumerate every tag in a `quarantine/<image>` repository,
@@ -41,7 +42,7 @@ referrer describing the decision.
 
 ## How are the actions structured
 
-The scan-and-promote workflows follow the same **caller + reusable workflow**
+The promote-from-quarantine workflows follow the same **caller + reusable workflow**
 pattern as the mirror workflows, and the reusable workflows are assembled from
 small, single-purpose **composite actions** under
 [`.github/actions/`](../../../.github/actions/) (see the
@@ -60,23 +61,23 @@ repository gets a thin caller that only supplies configuration.
 │   ├── attach-scan-report/
 │   └── delete-image/
 └── workflows/
-    ├── _scan-image.yml          # reusable workflow — image-filesystem scan
-    ├── _scan-sbom-image.yml     # reusable workflow — SBOM-attestation scan (hardened images)
-    ├── scan-python.yml          # caller — quarantine/python  → golden/python
-    ├── scan-node.yml            # caller — quarantine/node    → golden/node
-    ├── scan-openjdk.yml         # caller — quarantine/openjdk → golden/openjdk
-    └── scan-hardened-python.yml # caller — quarantine/hardened/python → base/hardened/python (SBOM-based)
+    ├── _promote-from-quarantine.yml      # reusable workflow — image-filesystem scan
+    ├── _promote-from-quarantine-sbom.yml # reusable workflow — SBOM-attestation scan (hardened images)
+    ├── promote-from-quarantine-python.yml          # caller — quarantine/python  → golden/python
+    ├── promote-from-quarantine-node.yml            # caller — quarantine/node    → golden/node
+    ├── promote-from-quarantine-openjdk.yml         # caller — quarantine/openjdk → golden/openjdk
+    └── promote-from-quarantine-hardened-python.yml # caller — quarantine/hardened/python → base/hardened/python (SBOM-based)
 ```
 
-- **Display name:** `scan / quarantine/<image>` (e.g. `scan / quarantine/python`).
-- **Concurrency group:** `scan-quarantine-<image>` (e.g. `scan-quarantine-python`).
+- **Display name:** `promote from quarantine / quarantine/<image>` (e.g. `promote from quarantine / quarantine/python`).
+- **Concurrency group:** `promote-from-quarantine-<image>` (e.g. `promote-from-quarantine-python`).
 
 This is the third workflow category, alongside `mirror` and `build`. See the
 [naming conventions](../../contributing/workflow-naming.md).
 
-### Reusable workflow (`_scan-image.yml`)
+### Reusable workflow (`_promote-from-quarantine.yml`)
 
-`_scan-image.yml` is an internal workflow (the leading underscore marks it as
+`_promote-from-quarantine.yml` is an internal workflow (the leading underscore marks it as
 "do not run directly"). It is triggered only through `workflow_call` and exposes
 the following inputs:
 
@@ -115,17 +116,17 @@ job matrix so each tag is processed in its own parallel job:
    severity, package, installed/fixed versions, and whether it was blocking or
    excepted).
 
-### Caller workflows (`scan-<image>.yml`)
+### Caller workflows (`promote-from-quarantine-<image>.yml`)
 
 Each caller contains no shell logic. A caller only declares:
 
 - **Triggers** — a daily `schedule` (07:00 UTC, after the 06:00 mirror) and a
   manual `workflow_dispatch` exposing overrides for `severity_threshold`,
   `cve_exceptions`, and `dry_run`.
-- **Concurrency** — a per-image group (`scan-quarantine-<image>`) with
+- **Concurrency** — a per-image group (`promote-from-quarantine-<image>`) with
   `cancel-in-progress: false`.
 - **Permissions** — `contents: read`, `packages: write`.
-- **A single job** that calls `./.github/workflows/_scan-image.yml` via `uses:`,
+- **A single job** that calls `./.github/workflows/_promote-from-quarantine.yml` via `uses:`,
   passes the image-specific inputs, and forwards the `ghcr_delete_token` secret.
 
 Adding a new scanned repository is a copy-and-edit operation on a caller file
@@ -139,9 +140,9 @@ the `scan` job then processes each tag independently and in parallel, and the
 
 ```mermaid
 flowchart TD
-    A[schedule 07:00 UTC] --> C[caller scan-image.yml]
+    A[schedule 07:00 UTC] --> C[caller promote-from-quarantine-image.yml]
     B[workflow_dispatch + overrides] --> C
-    C -->|uses: with inputs| D[_scan-image.yml]
+    C -->|uses: with inputs| D[_promote-from-quarantine.yml]
     D --> E[enumerate job: login + enumerate-tags]
     E -->|tags-json matrix| F[scan job: one parallel job per tag]
     F --> G[scan-image: trivy image]
@@ -174,7 +175,7 @@ For each tag the gate is evaluated as follows:
   offending CVEs. Blocked images never fail the whole job; the run finishes and
   the summary lists every outcome.
 
-## SBOM-based scanning for hardened images (`_scan-sbom-image.yml`)
+## SBOM-based scanning for hardened images (`_promote-from-quarantine-sbom.yml`)
 
 Distroless images such as [Docker Hardened Images](https://docs.docker.com/dhi/)
 (DHI) ship no package-manager metadata, so `trivy image` cannot enumerate their
@@ -182,10 +183,10 @@ packages. Those images instead carry their package inventory as an **SBOM
 attestation** — an in-toto statement attached to each platform manifest as an
 OCI referrer. The mirror copies these referrers into quarantine (see
 [`copy_referrers`](image-mirror-workflows.md)), and a dedicated reusable
-workflow, `_scan-sbom-image.yml`, gates on the SBOM rather than the image
+workflow, `_promote-from-quarantine-sbom.yml`, gates on the SBOM rather than the image
 filesystem.
 
-It mirrors `_scan-image.yml` (same inputs, gate semantics, scan-report referrer,
+It mirrors `_promote-from-quarantine.yml` (same inputs, gate semantics, scan-report referrer,
 source deletion, and reporting) with these differences:
 
 - **Extra input `sbom_predicate_type`** (default `https://cyclonedx.org/bom/v1.6`;
@@ -210,10 +211,10 @@ source deletion, and reporting) with these differences:
   and signatures travel into the destination alongside the scan-report referrer.
 
 The scan-report referrer records the scan method in `com.cssc.scan.method`
-(`image` for `_scan-image.yml`, `sbom` here) and, for SBOM scans, adds
+(`image` for `_promote-from-quarantine.yml`, `sbom` here) and, for SBOM scans, adds
 `com.cssc.scan.sbom-predicate-type=<predicate type>`.
 
-The `scan-hardened-python.yml` caller wires this workflow for
+The `promote-from-quarantine-hardened-python.yml` caller wires this workflow for
 `quarantine/hardened/python → base/hardened/python`. Hardened images are
 promoted into a dedicated `base/hardened/<image>` namespace rather than the
 `golden/<image>` scheme; see the
@@ -305,8 +306,8 @@ The workflow therefore treats deletion as configurable:
 ### Not implemented (deliberately out of scope)
 
 - **No signing.** Promoted images are not signed (e.g. cosign). The image-based
-  scanner (`_scan-image.yml`) produces no SBOM/provenance; the SBOM-based
-  scanner (`_scan-sbom-image.yml`) does not generate attestations but copies the
+  scanner (`_promote-from-quarantine.yml`) produces no SBOM/provenance; the SBOM-based
+  scanner (`_promote-from-quarantine-sbom.yml`) does not generate attestations but copies the
   upstream's existing SBOM/provenance/VEX/signature referrers verbatim during
   promotion.
 - **No automatic remediation.** Blocked images are left in quarantine; the
@@ -317,9 +318,9 @@ The workflow therefore treats deletion as configurable:
 - **No notification/alerting.** Failures and blocked images surface only through
   the normal GitHub Actions run status and the job summary.
 
-## Adding a new scanned repository
+## Adding a new promote-from-quarantine workflow
 
-1. Copy `scan-python.yml` to `scan-<image>.yml`.
+1. Copy `promote-from-quarantine-python.yml` to `promote-from-quarantine-<image>.yml`.
 2. Update the display `name:`, the `concurrency.group`, and the inputs
    (`source_repo`, `dest_repo`, and any threshold/exception overrides).
 3. No logic changes are needed — the reusable workflow does the work.

--- a/docs/contributing/workflow-naming.md
+++ b/docs/contributing/workflow-naming.md
@@ -11,7 +11,7 @@ both in the file system and in the Actions UI.
 | Category | Purpose | Workflow file | Display `name:` | Concurrency group |
 | -------- | ------- | ------------- | --------------- | ----------------- |
 | **Mirror** | Copy / refresh a base image from an upstream registry into GHCR | `mirror-<image>.yml` | `mirror / quarantine/<image>` | `mirror-quarantine-<image>` |
-| **Promote from quarantine** | Scan a quarantined image and promote it into `golden/<image>` when it passes the vulnerability policy | `promote-from-quarantine-<image>.yml` | `promote from quarantine / quarantine/<image>` | `promote-from-quarantine-<image>` |
+| **Promote from quarantine** | Scan a quarantined image and promote it into its golden/base repository (`golden/<image>`, or `base/...` for base/hardened images) when it passes the vulnerability policy | `promote-from-quarantine-<image>.yml` | `promote from quarantine / quarantine/<image>` | `promote-from-quarantine-<image>` |
 | **Build** | Build an application image on top of a mirrored base | `build-<app>.yml` | `build / <app>` | `build-<app>` |
 | **Reusable** | Shared logic invoked by other workflows; never triggered directly | `_<purpose>.yml` (leading underscore) | `_reusable / <purpose>` | n/a |
 | **Composite action** | A single reusable step shared across workflows | `.github/actions/<verb-noun>/action.yml` | `name: <verb-noun>` | n/a |
@@ -34,7 +34,9 @@ both in the file system and in the Actions UI.
    `quarantine/<image>` scheme, e.g. `ghcr.io/<owner>/quarantine/python`.
    Images promoted out of quarantine by a promote-from-quarantine workflow
    follow the
-   `golden/<image>` scheme, e.g. `ghcr.io/<owner>/golden/python`.
+   `golden/<image>` scheme, e.g. `ghcr.io/<owner>/golden/python`, except for
+   base/hardened images which are promoted into the `base/...` namespace, e.g.
+   `ghcr.io/<owner>/base/node` or `ghcr.io/<owner>/base/hardened/python`.
 
 ## Mirror workflows
 
@@ -69,7 +71,8 @@ Promote-from-quarantine workflows gate images out of quarantine. They scan every
 tag in a
 `quarantine/<image>` repository with Trivy and promote the images that pass a
 configurable severity threshold (plus an optional CVE exception list) into a
-`golden/<image>` repository.
+`golden/<image>` repository (or a `base/...` repository for base/hardened
+images).
 
 - **Structure.** Logic lives in a single reusable workflow,
   [`_promote-from-quarantine.yml`](../../.github/workflows/_promote-from-quarantine.yml), which is

--- a/docs/contributing/workflow-naming.md
+++ b/docs/contributing/workflow-naming.md
@@ -11,7 +11,7 @@ both in the file system and in the Actions UI.
 | Category | Purpose | Workflow file | Display `name:` | Concurrency group |
 | -------- | ------- | ------------- | --------------- | ----------------- |
 | **Mirror** | Copy / refresh a base image from an upstream registry into GHCR | `mirror-<image>.yml` | `mirror / quarantine/<image>` | `mirror-quarantine-<image>` |
-| **Scan** | Scan a quarantined image and promote it into `golden/<image>` when it passes the vulnerability policy | `scan-<image>.yml` | `scan / quarantine/<image>` | `scan-quarantine-<image>` |
+| **Promote from quarantine** | Scan a quarantined image and promote it into `golden/<image>` when it passes the vulnerability policy | `promote-from-quarantine-<image>.yml` | `promote from quarantine / quarantine/<image>` | `promote-from-quarantine-<image>` |
 | **Build** | Build an application image on top of a mirrored base | `build-<app>.yml` | `build / <app>` | `build-<app>` |
 | **Reusable** | Shared logic invoked by other workflows; never triggered directly | `_<purpose>.yml` (leading underscore) | `_reusable / <purpose>` | n/a |
 | **Composite action** | A single reusable step shared across workflows | `.github/actions/<verb-noun>/action.yml` | `name: <verb-noun>` | n/a |
@@ -19,7 +19,8 @@ both in the file system and in the Actions UI.
 ### Rules
 
 1. **Verb prefix.** Every workflow filename starts with a category verb:
-   `mirror-`, `scan-`, `build-`, or a leading underscore (`_`) for reusable
+   `mirror-`, `promote-from-quarantine-`, `build-`, or a leading underscore
+   (`_`) for reusable
    workflows. This groups related workflows together alphabetically and makes
    intent obvious at a glance.
 2. **Leading underscore = internal.** Reusable workflows (triggered by
@@ -31,7 +32,8 @@ both in the file system and in the Actions UI.
    job never overlap, while different images/apps run independently.
 5. **GHCR destination repositories** for mirrored base images follow the
    `quarantine/<image>` scheme, e.g. `ghcr.io/<owner>/quarantine/python`.
-   Images promoted out of quarantine by a scan workflow follow the
+   Images promoted out of quarantine by a promote-from-quarantine workflow
+   follow the
    `golden/<image>` scheme, e.g. `ghcr.io/<owner>/golden/python`.
 
 ## Mirror workflows
@@ -61,20 +63,21 @@ Mirror workflows keep a copy of an upstream base image fresh in GHCR.
    (`source_image`, `source_tag`, `dest_image`, `dest_tag`).
 3. No logic changes are needed — the reusable workflow does the work.
 
-## Scan workflows
+## Promote-from-quarantine workflows
 
-Scan workflows gate images out of quarantine. They scan every tag in a
+Promote-from-quarantine workflows gate images out of quarantine. They scan every
+tag in a
 `quarantine/<image>` repository with Trivy and promote the images that pass a
 configurable severity threshold (plus an optional CVE exception list) into a
 `golden/<image>` repository.
 
 - **Structure.** Logic lives in a single reusable workflow,
-  [`_scan-image.yml`](../../.github/workflows/_scan-image.yml), which is
+  [`_promote-from-quarantine.yml`](../../.github/workflows/_promote-from-quarantine.yml), which is
   assembled from composite actions under `.github/actions/` (see
   [workflow actions](../reference/workflow-actions.md)) and fans the work out
   across a job matrix (one job per tag). Each scanned
   repository has a thin caller, e.g.
-  [`scan-python.yml`](../../.github/workflows/scan-python.yml), that only
+  [`promote-from-quarantine-python.yml`](../../.github/workflows/promote-from-quarantine-python.yml), that only
   declares triggers and the repository-specific inputs and calls the reusable
   workflow via `uses:`.
 - **Gate + promote.** Passing images are copied with `crane copy`, get an empty
@@ -86,11 +89,11 @@ configurable severity threshold (plus an optional CVE exception list) into a
 - **Auth.** GHCR scan/copy/attach use the built-in `GITHUB_TOKEN`
   (`packages: write`). Deleting quarantine tags needs a separate
   `delete:packages` PAT (see the
-  [scan-and-promote architecture](../architecture/workflows/scan-and-promote-workflows.md)).
+  [promote-from-quarantine architecture](../architecture/workflows/promote-from-quarantine-workflows.md)).
 
-### Adding a new scan workflow
+### Adding a new promote-from-quarantine workflow
 
-1. Copy `scan-python.yml` to `scan-<image>.yml`.
+1. Copy `promote-from-quarantine-python.yml` to `promote-from-quarantine-<image>.yml`.
 2. Update the display `name:`, the `concurrency.group`, and the inputs
    (`source_repo`, `dest_repo`, and any threshold/exception overrides).
 3. No logic changes are needed — the reusable workflow does the work.

--- a/docs/reference/workflow-actions.md
+++ b/docs/reference/workflow-actions.md
@@ -149,7 +149,7 @@ Attach an empty OCI scan-report referrer to a promoted image.
 | `sbom-predicate-type` | no | `""` | Recorded only when `method` is `sbom`. |
 
 The referrer artifact type is `application/vnd.cssc.scan-report.v1+json`; see the
-[scan-and-promote architecture](../architecture/workflows/scan-and-promote-workflows.md#scan-report-referrer-artifact)
+[promote-from-quarantine architecture](../architecture/workflows/promote-from-quarantine-workflows.md#scan-report-referrer-artifact)
 for the full annotation schema.
 
 ### delete-image
@@ -172,7 +172,7 @@ A single job: check out, set up `crane` (and `oras` when copying referrers), run
 **registry-login** for the source (when authenticated) and GHCR, then
 **mirror-image**, then write a summary from its outputs.
 
-### Scan workflows (`_scan-image.yml`, `_scan-sbom-image.yml`)
+### Promote-from-quarantine workflows (`_promote-from-quarantine.yml`, `_promote-from-quarantine-sbom.yml`)
 
 A matrix fan-out across three jobs:
 


### PR DESCRIPTION
## Summary

Follow-up to #61. Resolves the remaining Node.js 20 deprecation warning and renames the scan-and-promote workflows to a clearer taxonomy.

### Node.js 24
- `actions/upload-artifact` → `v7.0.1` and `actions/download-artifact` → `v8.0.1`. The previously pinned `v5.0.0` of both still defaults to the deprecated Node 20 runtime (Node 24 was only preliminary until v6), which is what kept emitting the warning.
- Reviewed all other actions: `checkout@v5.0.0` and `setup-oras@v2.0.0` already run Node 24; `setup-crane` and `setup-trivy` are composite actions (no Node runtime).
- Default-archive artifact usage (`pattern: scan-result-* merge-multiple`) is unaffected by the v8 download breaking changes.

### Rename: scan → promote from quarantine
Since these workflows scan **and** promote, they are renamed to the `promote-from-quarantine` scheme:

| Old | New |
|-----|-----|
| `_scan-image.yml` | `_promote-from-quarantine.yml` |
| `_scan-sbom-image.yml` | `_promote-from-quarantine-sbom.yml` |
| `scan-{python,node,openjdk,hardened-python}.yml` | `promote-from-quarantine-*.yml` |
| `docs/.../scan-and-promote-workflows.md` | `docs/.../promote-from-quarantine-workflows.md` |

Display names (`promote from quarantine / quarantine/<image>`), concurrency groups, job IDs, the naming-convention category, and all doc references are updated. The pure-scan composite actions (`scan-image`, `scan-sbom`) and `scan-result-*` artifact names are intentionally left unchanged for future scan-only / promote-only actions.

All six workflow files validate with no errors.