### PR TITLE
Disable automatic schedules for hardened python workflows

### DIFF
--- a/.github/workflows/mirror-hardened-python.yml
+++ b/.github/workflows/mirror-hardened-python.yml
@@ -12,9 +12,9 @@
 name: mirror / quarantine/hardened/python
 
 on:
-  # Daily upstream check at 06:00 UTC.
-  schedule:
-    - cron: "0 6 * * *"
+  # Automatic daily schedule disabled; this workflow runs on manual dispatch only.
+  # schedule:
+  #   - cron: "0 6 * * *"  # Daily upstream check at 06:00 UTC.
   # Manual run, with an optional force copy.
   workflow_dispatch:
     inputs:

--- a/.github/workflows/promote-from-quarantine-hardened-python.yml
+++ b/.github/workflows/promote-from-quarantine-hardened-python.yml
@@ -21,9 +21,9 @@
 name: promote from quarantine / quarantine/hardened/python
 
 on:
-  # Daily scan at 07:00 UTC, after the 06:00 mirror has refreshed quarantine.
-  schedule:
-    - cron: "0 7 * * *"
+  # Automatic daily schedule disabled; this workflow runs on manual dispatch only.
+  # schedule:
+  #   - cron: "0 7 * * *"  # Daily scan at 07:00 UTC, after the 06:00 mirror has refreshed quarantine.
   # Manual run with policy overrides.
   workflow_dispatch:
     inputs:


### PR DESCRIPTION
## Summary

Disables the automatic daily cron schedules for the Docker Hardened Image (DHI) python workflows so they no longer run unattended. Both workflows remain triggerable manually via `workflow_dispatch`.

## Changes

- **mirror-hardened-python.yml**: commented out the `schedule` trigger (was `cron: "0 6 * * *"`).
- **promote-from-quarantine-hardened-python.yml**: commented out the `schedule` trigger (was `cron: "0 7 * * *"`).
- Removed two stale, untracked pre-rename leftover files from the working tree (`_scan-image.yml`, `_scan-sbom-image.yml`). Their renamed replacements (`_promote-from-quarantine*.yml`) are already tracked on `main`; the leftovers were obsolete copies from the rename in b76db11.

## Notes

No functional change to the reusable workflows themselves — only triggers were adjusted. Re-enable by uncommenting the `schedule:` blocks.