### PR TITLE
feat: human-in-the-loop override approval for blocked promotions

### DIFF
--- a/.github/actions/attach-scan-report/action.yml
+++ b/.github/actions/attach-scan-report/action.yml
@@ -37,6 +37,22 @@ inputs:
     description: "in-toto predicate type scanned; recorded only when method is 'sbom'."
     required: false
     default: ""
+  override:
+    description: "Set to 'true' when the image was promoted via a manual override despite failing the gate."
+    required: false
+    default: "false"
+  override-approver:
+    description: "Login that approved the override (recorded only when override is true)."
+    required: false
+    default: ""
+  override-issue:
+    description: "Tracking issue URL for the override (recorded only when override is true)."
+    required: false
+    default: ""
+  override-cves:
+    description: "Pipe-separated CVEs that were overridden (recorded only when override is true)."
+    required: false
+    default: ""
 
 runs:
   using: composite
@@ -52,6 +68,10 @@ runs:
         SCANNER_VERSION: "${{ inputs.scanner-version }}"
         METHOD: "${{ inputs.method }}"
         SBOM_PREDICATE_TYPE: "${{ inputs.sbom-predicate-type }}"
+        OVERRIDE: "${{ inputs.override }}"
+        OVERRIDE_APPROVER: "${{ inputs.override-approver }}"
+        OVERRIDE_ISSUE: "${{ inputs.override-issue }}"
+        OVERRIDE_CVES: "${{ inputs.override-cves }}"
       run: |
         set -euo pipefail
         export LC_ALL=C
@@ -73,6 +93,14 @@ runs:
         if [ "${METHOD}" = "sbom" ]; then
           args+=(
             --annotation "com.cssc.scan.sbom-predicate-type=${SBOM_PREDICATE_TYPE}"
+          )
+        fi
+        if [ "${OVERRIDE}" = "true" ]; then
+          args+=(
+            --annotation "com.cssc.scan.override=true"
+            --annotation "com.cssc.scan.override-approver=${OVERRIDE_APPROVER}"
+            --annotation "com.cssc.scan.override-issue=${OVERRIDE_ISSUE}"
+            --annotation "com.cssc.scan.override-cves=${OVERRIDE_CVES}"
           )
         fi
 

--- a/.github/actions/attach-scan-report/action.yml
+++ b/.github/actions/attach-scan-report/action.yml
@@ -96,6 +96,13 @@ runs:
           )
         fi
         if [ "${OVERRIDE}" = "true" ]; then
+          # An override claim is only trustworthy if it names who approved it
+          # and links the tracking issue; refuse to write a half-populated
+          # provenance record that would weaken the audit trail.
+          if [ -z "${OVERRIDE_APPROVER}" ] || [ -z "${OVERRIDE_ISSUE}" ]; then
+            echo "::error::override=true requires both override-approver and override-issue to be set" >&2
+            exit 1
+          fi
           args+=(
             --annotation "com.cssc.scan.override=true"
             --annotation "com.cssc.scan.override-approver=${OVERRIDE_APPROVER}"

--- a/.github/actions/manage-issue/action.yml
+++ b/.github/actions/manage-issue/action.yml
@@ -114,6 +114,18 @@ runs:
 
         case "${OPERATION}" in
           open-or-update)
+            # The embedded metadata block is the source of truth a later
+            # override run reads back, so refuse to open/update with missing or
+            # malformed JSON rather than writing a garbled block.
+            if [ -z "${METADATA_JSON}" ]; then
+              echo "::error::operation=open-or-update requires a non-empty metadata-json" >&2
+              exit 1
+            fi
+            if ! printf '%s' "${METADATA_JSON}" | jq -e . >/dev/null 2>&1; then
+              echo "::error::operation=open-or-update requires metadata-json to be valid JSON" >&2
+              exit 1
+            fi
+
             # Compose the body: human text + a delimited metadata block.
             body_file="$(mktemp)"
             {

--- a/.github/actions/manage-issue/action.yml
+++ b/.github/actions/manage-issue/action.yml
@@ -1,0 +1,200 @@
+# Composite action: manage-issue
+#
+# Manage the lifecycle of a per-image+tag promotion tracking issue using the
+# GitHub REST API via `gh` (authenticated with GITHUB_TOKEN; needs
+# `issues: write`). Three operations:
+#
+#   open-or-update - idempotently create the tracking issue, or update an
+#                    existing one. Dedupes by the `promotion-pending` label plus
+#                    a deterministic title ("Promotion blocked: <image>:<tag>").
+#                    Embeds a machine-readable metadata block in the body so a
+#                    later override run can recover the promotion parameters.
+#   comment        - append a comment to the issue.
+#   close          - apply the outcome label (promotion-approved|promotion-denied),
+#                    remove promotion-pending, post a closing comment, and close.
+#
+# The metadata block is delimited by HTML comment markers and contains the JSON
+# passed in `metadata-json`; `open-or-update` and the `metadata-json` output use
+# these markers to round-trip the data.
+#
+# Terminology: see docs/reference/workflow-actions.md.
+name: manage-issue
+description: Create, update, comment on, or close a promotion tracking issue.
+
+inputs:
+  operation:
+    description: "open-or-update | comment | close | get."
+    required: true
+  image:
+    description: "Source repository (used for dedupe + metadata)."
+    required: true
+  tag:
+    description: "Image tag (used for dedupe + metadata)."
+    required: true
+  metadata-json:
+    description: "Machine-readable JSON embedded in the body (open-or-update)."
+    required: false
+    default: ""
+  body:
+    description: "Human-readable issue body (open-or-update) or comment text (comment)."
+    required: false
+    default: ""
+  outcome:
+    description: "close only: promotion-approved | promotion-denied."
+    required: false
+    default: ""
+  issue-number:
+    description: "Target issue number for comment/close. When empty it is resolved by title."
+    required: false
+    default: ""
+  token:
+    description: "GITHUB_TOKEN with issues: write."
+    required: true
+
+outputs:
+  issue-number:
+    description: "The resolved/created issue number (empty if none)."
+    value: ${{ steps.manage.outputs.issue-number }}
+  issue-url:
+    description: "The resolved/created issue URL (empty if none)."
+    value: ${{ steps.manage.outputs.issue-url }}
+  metadata-json:
+    description: "Metadata JSON parsed out of an existing issue (empty if none)."
+    value: ${{ steps.manage.outputs.metadata-json }}
+
+runs:
+  using: composite
+  steps:
+    - name: Manage tracking issue
+      id: manage
+      shell: bash
+      env:
+        GH_TOKEN: "${{ inputs.token }}"
+        GH_REPO: "${{ github.repository }}"
+        OPERATION: "${{ inputs.operation }}"
+        IMAGE: "${{ inputs.image }}"
+        TAG: "${{ inputs.tag }}"
+        METADATA_JSON: "${{ inputs.metadata-json }}"
+        BODY_IN: "${{ inputs.body }}"
+        OUTCOME: "${{ inputs.outcome }}"
+        ISSUE_NUMBER_IN: "${{ inputs.issue-number }}"
+      run: |
+        set -euo pipefail
+        export LC_ALL=C
+
+        title="Promotion blocked: ${IMAGE}:${TAG}"
+        pending_label="promotion-pending"
+        meta_start="<!-- cssc-metadata:start -->"
+        meta_end="<!-- cssc-metadata:end -->"
+
+        # Ensure the labels we rely on exist (idempotent; ignore "already exists").
+        ensure_label () {
+          gh label create "$1" --color "$2" --description "$3" >/dev/null 2>&1 || true
+        }
+        ensure_label "${pending_label}" "d93f0b" "Image awaiting promotion override decision"
+        ensure_label "promotion-approved" "0e8a16" "Promotion override approved"
+        ensure_label "promotion-denied" "b60205" "Promotion override denied"
+
+        # Resolve an existing open tracking issue number by exact title (scoped to
+        # the pending label) unless one was passed explicitly.
+        resolve_number () {
+          if [ -n "${ISSUE_NUMBER_IN}" ]; then
+            printf '%s' "${ISSUE_NUMBER_IN}"
+            return
+          fi
+          gh issue list --state open --label "${pending_label}" \
+            --search "in:title ${title}" --json number,title \
+            --jq ".[] | select(.title == \"${title}\") | .number" 2>/dev/null \
+            | head -n1 || true
+        }
+
+        out_number=""
+        out_url=""
+        out_meta=""
+
+        case "${OPERATION}" in
+          open-or-update)
+            # Compose the body: human text + a delimited metadata block.
+            body_file="$(mktemp)"
+            {
+              if [ -n "${BODY_IN}" ]; then
+                printf '%s\n\n' "${BODY_IN}"
+              else
+                printf '%s\n\n' "Image \`${IMAGE}:${TAG}\` failed the vulnerability gate and is awaiting an approve/deny decision. Comment \`/approve\` or \`/deny\` on this issue."
+              fi
+              printf '%s\n' "${meta_start}"
+              printf '```json\n%s\n```\n' "${METADATA_JSON}"
+              printf '%s\n' "${meta_end}"
+            } > "${body_file}"
+
+            existing="$(resolve_number)"
+            if [ -n "${existing}" ]; then
+              gh issue edit "${existing}" --body-file "${body_file}" >/dev/null
+              gh issue comment "${existing}" \
+                --body "Re-scanned on $(date -u +%Y-%m-%dT%H:%M:%SZ); image still blocked." >/dev/null
+              out_number="${existing}"
+            else
+              url="$(gh issue create --title "${title}" --label "${pending_label}" \
+                     --body-file "${body_file}")"
+              out_url="${url}"
+              out_number="$(printf '%s' "${url}" | sed 's:.*/::')"
+            fi
+            ;;
+
+          comment)
+            existing="$(resolve_number)"
+            if [ -z "${existing}" ]; then
+              echo "::warning::No tracking issue found for ${IMAGE}:${TAG}; nothing to comment."
+            else
+              gh issue comment "${existing}" --body "${BODY_IN}" >/dev/null
+              out_number="${existing}"
+            fi
+            ;;
+
+          close)
+            existing="$(resolve_number)"
+            if [ -z "${existing}" ]; then
+              echo "::warning::No tracking issue found for ${IMAGE}:${TAG}; nothing to close."
+            else
+              case "${OUTCOME}" in
+                promotion-approved|promotion-denied) : ;;
+                *) echo "::error::close requires outcome=promotion-approved|promotion-denied"; exit 1 ;;
+              esac
+              gh issue edit "${existing}" \
+                --add-label "${OUTCOME}" --remove-label "${pending_label}" >/dev/null
+              [ -n "${BODY_IN}" ] && gh issue comment "${existing}" --body "${BODY_IN}" >/dev/null
+              gh issue close "${existing}" >/dev/null
+              out_number="${existing}"
+            fi
+            ;;
+
+          get)
+            out_number="$(resolve_number)"
+            if [ -z "${out_number}" ]; then
+              echo "::warning::No tracking issue found for ${IMAGE}:${TAG}."
+            fi
+            ;;
+
+          *)
+            echo "::error::Invalid operation '${OPERATION}' (expected open-or-update|comment|close|get)"
+            exit 1 ;;
+        esac
+
+        # Backfill url + metadata for whichever issue we ended up with.
+        if [ -n "${out_number}" ]; then
+          [ -z "${out_url}" ] && out_url="$(gh issue view "${out_number}" --json url --jq '.url' 2>/dev/null || true)"
+          body="$(gh issue view "${out_number}" --json body --jq '.body' 2>/dev/null || true)"
+          out_meta="$(printf '%s' "${body}" \
+            | tr -d '\r' \
+            | sed -n "/${meta_start}/,/${meta_end}/p" \
+            | sed -n 's/^```json$//; /^```$/d; /cssc-metadata/d; p' \
+            | jq -c '.' 2>/dev/null || true)"
+        fi
+
+        echo "issue-number=${out_number}" >> "${GITHUB_OUTPUT}"
+        echo "issue-url=${out_url}" >> "${GITHUB_OUTPUT}"
+        {
+          echo "metadata-json<<CSSC_META_EOF"
+          printf '%s\n' "${out_meta}"
+          echo "CSSC_META_EOF"
+        } >> "${GITHUB_OUTPUT}"

--- a/.github/actions/notify-slack/action.yml
+++ b/.github/actions/notify-slack/action.yml
@@ -1,0 +1,120 @@
+# Composite action: notify-slack
+#
+# Post a formatted message to a Slack incoming webhook describing a
+# promote-from-quarantine override event. Three message templates are selected
+# by `status`:
+#   blocked-pending - an image failed the gate and awaits an approve/deny.
+#   approved        - an override was approved and the image was promoted.
+#   denied          - an override was denied; the image stays in quarantine.
+#
+# When `webhook-url` is empty the action is a no-op (with a warning) so callers
+# can leave Slack unconfigured without failing.
+#
+# Terminology: see docs/reference/workflow-actions.md.
+name: notify-slack
+description: Post an override-event message to a Slack incoming webhook.
+
+inputs:
+  webhook-url:
+    description: "Slack incoming webhook URL. When empty the action is a no-op."
+    required: false
+    default: ""
+  status:
+    description: "Message template: blocked-pending | approved | denied."
+    required: true
+  image:
+    description: "Source repository (e.g. ghcr.io/owner/quarantine/python)."
+    required: true
+  tag:
+    description: "Image tag."
+    required: true
+  threshold:
+    description: "Severity threshold the image failed (optional)."
+    required: false
+    default: ""
+  blocking-cves:
+    description: "Human-readable summary of blocking CVEs (optional)."
+    required: false
+    default: ""
+  issue-url:
+    description: "Link to the tracking issue (optional)."
+    required: false
+    default: ""
+  run-url:
+    description: "Link to the workflow run (optional)."
+    required: false
+    default: ""
+  approver:
+    description: "Login recorded for approved/denied messages (optional)."
+    required: false
+    default: ""
+
+runs:
+  using: composite
+  steps:
+    - name: Post Slack message
+      shell: bash
+      env:
+        WEBHOOK_URL: "${{ inputs.webhook-url }}"
+        STATUS: "${{ inputs.status }}"
+        IMAGE: "${{ inputs.image }}"
+        TAG: "${{ inputs.tag }}"
+        THRESHOLD: "${{ inputs.threshold }}"
+        BLOCKING_CVES: "${{ inputs.blocking-cves }}"
+        ISSUE_URL: "${{ inputs.issue-url }}"
+        RUN_URL: "${{ inputs.run-url }}"
+        APPROVER: "${{ inputs.approver }}"
+      run: |
+        set -euo pipefail
+        export LC_ALL=C
+
+        if [ -z "${WEBHOOK_URL}" ]; then
+          echo "::warning::No Slack webhook configured; skipping ${STATUS} notification for ${IMAGE}:${TAG}."
+          exit 0
+        fi
+
+        case "${STATUS}" in
+          blocked-pending)
+            header=":no_entry: Promotion blocked — approval needed"
+            summary="*${IMAGE}:${TAG}* failed the \`${THRESHOLD:-?}\` vulnerability gate." ;;
+          approved)
+            header=":white_check_mark: Promotion override approved"
+            summary="*${IMAGE}:${TAG}* was promoted despite the gate${APPROVER:+ by ${APPROVER}}." ;;
+          denied)
+            header=":x: Promotion override denied"
+            summary="*${IMAGE}:${TAG}* stays in quarantine${APPROVER:+ (denied by ${APPROVER})}." ;;
+          *)
+            echo "::error::Invalid status '${STATUS}' (expected blocked-pending|approved|denied)"; exit 1 ;;
+        esac
+
+        # Assemble the context line (CVEs / links) from whichever fields are set.
+        context=""
+        [ -n "${BLOCKING_CVES}" ] && context="${context}Blocking CVEs: ${BLOCKING_CVES}\n"
+        [ -n "${ISSUE_URL}" ]     && context="${context}Issue: ${ISSUE_URL}\n"
+        [ -n "${RUN_URL}" ]       && context="${context}Run: ${RUN_URL}\n"
+
+        # Build the Block Kit payload with jq so all text is safely JSON-encoded.
+        payload="$(jq -n \
+          --arg header "${header}" \
+          --arg summary "${summary}" \
+          --arg context "${context}" \
+          '{
+            blocks: (
+              [
+                { type: "header", text: { type: "plain_text", text: $header, emoji: true } },
+                { type: "section", text: { type: "mrkdwn", text: $summary } }
+              ]
+              + (if ($context | length) > 0
+                 then [ { type: "section", text: { type: "mrkdwn", text: $context } } ]
+                 else [] end)
+            )
+          }')"
+
+        code="$(curl -sS -o /dev/null -w '%{http_code}' \
+          -X POST -H 'Content-Type: application/json' \
+          --data "${payload}" "${WEBHOOK_URL}")"
+        if [ "${code}" != "200" ]; then
+          echo "::error::Slack webhook returned HTTP ${code}."
+          exit 1
+        fi
+        echo "Posted ${STATUS} notification for ${IMAGE}:${TAG}."

--- a/.github/actions/verify-approver/action.yml
+++ b/.github/actions/verify-approver/action.yml
@@ -1,0 +1,85 @@
+# Composite action: verify-approver
+#
+# Confirm that an actor has sufficient repository permission before an override
+# (promoting an image that failed the vulnerability gate) is honored. Anyone can
+# comment `/approve` or `/deny` on a tracking issue, so the override workflow
+# must check the commenter's permission before acting.
+#
+# Calls GET /repos/{owner}/{repo}/collaborators/{actor}/permission and compares
+# the returned role against `min-permission`. Sets output `authorized` and, by
+# default, fails the step when the actor is below the threshold.
+#
+# Terminology: see docs/reference/workflow-actions.md.
+name: verify-approver
+description: Verify an actor meets a minimum repository permission for overrides.
+
+inputs:
+  actor:
+    description: "The login that issued the command."
+    required: true
+  min-permission:
+    description: "Minimum permission: admin | maintain | write."
+    required: false
+    default: "maintain"
+  fail-on-unauthorized:
+    description: "Fail the step when the actor is below the threshold."
+    required: false
+    default: "true"
+  token:
+    description: "GITHUB_TOKEN (or PAT) able to read collaborator permissions."
+    required: true
+
+outputs:
+  authorized:
+    description: "true | false."
+    value: ${{ steps.verify.outputs.authorized }}
+
+runs:
+  using: composite
+  steps:
+    - name: Verify ${{ inputs.actor }} permission
+      id: verify
+      shell: bash
+      env:
+        GH_TOKEN: "${{ inputs.token }}"
+        GH_REPO: "${{ github.repository }}"
+        ACTOR: "${{ inputs.actor }}"
+        MIN_PERMISSION: "${{ inputs.min-permission }}"
+        FAIL_ON_UNAUTHORIZED: "${{ inputs.fail-on-unauthorized }}"
+      run: |
+        set -euo pipefail
+        export LC_ALL=C
+
+        # Map a permission name to a numeric rank for comparison.
+        rank () {
+          case "$1" in
+            admin)    echo 4 ;;
+            maintain) echo 3 ;;
+            write)    echo 2 ;;
+            read)     echo 1 ;;
+            *)        echo 0 ;;
+          esac
+        }
+
+        min_rank="$(rank "${MIN_PERMISSION}")"
+        if [ "${min_rank}" -eq 0 ]; then
+          echo "::error::Invalid min-permission '${MIN_PERMISSION}' (expected admin|maintain|write)"
+          exit 1
+        fi
+
+        # role_name reflects the highest base/role permission (admin|maintain|write|read|none).
+        role="$(gh api "repos/${GH_REPO}/collaborators/${ACTOR}/permission" \
+                --jq '.role_name // .permission // "none"' 2>/dev/null || echo "none")"
+        actor_rank="$(rank "${role}")"
+
+        if [ "${actor_rank}" -ge "${min_rank}" ]; then
+          echo "${ACTOR} has '${role}' permission (>= ${MIN_PERMISSION}); authorized."
+          echo "authorized=true" >> "${GITHUB_OUTPUT}"
+        else
+          echo "::warning::${ACTOR} has '${role}' permission (< ${MIN_PERMISSION}); not authorized."
+          echo "authorized=false" >> "${GITHUB_OUTPUT}"
+          if [ "${FAIL_ON_UNAUTHORIZED}" = "true" ]; then
+            echo "::error::${ACTOR} is not authorized to approve overrides."
+            exit 1
+          fi
+        fi

--- a/.github/workflows/_promote-from-quarantine-sbom.yml
+++ b/.github/workflows/_promote-from-quarantine-sbom.yml
@@ -145,7 +145,6 @@ jobs:
     permissions:
       contents: read
       packages: write
-      issues: write
     strategy:
       fail-fast: false
       matrix:
@@ -265,10 +264,11 @@ jobs:
           token: ${{ secrets.ghcr_delete_token }}
 
       # When approval is enabled and the image is blocked (including a missing
-      # SBOM), build a machine-readable metadata block, open/refresh the
-      # tracking issue, and notify Slack for a manual approve/deny override.
-      - name: Build override metadata
-        id: meta
+      # SBOM), persist a machine-readable metadata block alongside the per-tag
+      # result. The downstream `notify` job (which alone holds `issues: write`)
+      # reads it back to open the tracking issue and send the Slack alert, so
+      # this scan matrix never needs issue-write permission.
+      - name: Persist override metadata
         if: startsWith(steps.evaluate.outputs.decision, 'blocked') && inputs.enable_approval
         env:
           REMAINING_MD: "${{ steps.evaluate.outputs.remaining-md }}"
@@ -276,13 +276,17 @@ jobs:
           set -euo pipefail
           export LC_ALL=C
 
+          safe="${TAG//[^A-Za-z0-9_.-]/_}"
+          out="${RUNNER_TEMP}/result/${safe}"
+          mkdir -p "${out}"
+
           digest="$(crane digest "${SOURCE_REPO}:${TAG}" 2>/dev/null || true)"
 
           cves_json="$(printf '%s' "${REMAINING_MD}" | tr ',' '\n' \
             | sed 's/^[[:space:]]*//; s/[[:space:]]*$//' \
             | jq -R . | jq -sc 'map(select(length > 0))')"
 
-          meta="$(jq -nc \
+          jq -nc \
             --arg sr "${SOURCE_REPO}" \
             --arg dr "${DEST_REPO}" \
             --arg tag "${TAG}" \
@@ -293,37 +297,7 @@ jobs:
             --argjson cves "${cves_json}" \
             '{source_repo:$sr, dest_repo:$dr, tag:$tag, digest:$digest,
               threshold:$th, scanner:"trivy", scanner_version:$sv,
-              method:"sbom", sbom_predicate_type:$pt, blocking_cves:$cves}')"
-
-          {
-            echo "metadata-json<<CSSC_META_EOF"
-            printf '%s\n' "${meta}"
-            echo "CSSC_META_EOF"
-          } >> "${GITHUB_OUTPUT}"
-
-      - name: Open promotion tracking issue
-        id: issue
-        if: startsWith(steps.evaluate.outputs.decision, 'blocked') && inputs.enable_approval
-        uses: ./.github/actions/manage-issue
-        with:
-          operation: open-or-update
-          image: ${{ inputs.source_repo }}
-          tag: ${{ matrix.tag }}
-          metadata-json: ${{ steps.meta.outputs.metadata-json }}
-          token: ${{ github.token }}
-
-      - name: Notify Slack of blocked image
-        if: startsWith(steps.evaluate.outputs.decision, 'blocked') && inputs.enable_approval
-        uses: ./.github/actions/notify-slack
-        with:
-          webhook-url: ${{ secrets.slack_webhook }}
-          status: blocked-pending
-          image: ${{ inputs.source_repo }}
-          tag: ${{ matrix.tag }}
-          threshold: ${{ inputs.severity_threshold }}
-          blocking-cves: ${{ steps.evaluate.outputs.remaining-md }}
-          issue-url: ${{ steps.issue.outputs.issue-url }}
-          run-url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+              method:"sbom", sbom_predicate_type:$pt, blocking_cves:$cves}' > "${out}/override-metadata.json"
 
       - name: Record result
         if: always()
@@ -433,6 +407,83 @@ jobs:
           name: scan-result-${{ strategy.job-index }}
           path: ${{ runner.temp }}/result
           retention-days: 1
+
+  # --- Phase 2b: open tracking issues + notify Slack for blocked images. ------
+  # Split out from `scan` so that matrix never needs `issues: write`. Runs only
+  # when approval is enabled; matrixes over every tag and no-ops for any tag
+  # that the scan job did not flag as blocked (no override-metadata artifact).
+  notify:
+    needs: [enumerate, scan]
+    if: always() && inputs.enable_approval && needs.enumerate.outputs.has-tags == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+    strategy:
+      fail-fast: false
+      matrix:
+        tag: ${{ fromJSON(needs.enumerate.outputs.tags-json) }}
+    env:
+      SOURCE_REPO: "${{ inputs.source_repo }}"
+      TAG: "${{ matrix.tag }}"
+    steps:
+      - name: Check out actions
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+
+      - name: Download results
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          pattern: scan-result-*
+          path: ${{ runner.temp }}/results
+
+      - name: Locate override metadata for this tag
+        id: find
+        run: |
+          set -euo pipefail
+          export LC_ALL=C
+
+          safe="${TAG//[^A-Za-z0-9_.-]/_}"
+          meta_file="$(find "${RUNNER_TEMP}/results" -type f \
+            -path "*/${safe}/override-metadata.json" 2>/dev/null | head -n1 || true)"
+
+          if [ -z "${meta_file}" ] || [ ! -s "${meta_file}" ]; then
+            echo "blocked=false" >> "${GITHUB_OUTPUT}"
+            exit 0
+          fi
+
+          meta="$(jq -c . "${meta_file}")"
+          cves="$(printf '%s' "${meta}" | jq -r '(.blocking_cves // []) | join(", ")')"
+          echo "blocked=true" >> "${GITHUB_OUTPUT}"
+          echo "blocking-cves=${cves}" >> "${GITHUB_OUTPUT}"
+          {
+            echo "metadata-json<<CSSC_META_EOF"
+            printf '%s\n' "${meta}"
+            echo "CSSC_META_EOF"
+          } >> "${GITHUB_OUTPUT}"
+
+      - name: Open promotion tracking issue
+        id: issue
+        if: steps.find.outputs.blocked == 'true'
+        uses: ./.github/actions/manage-issue
+        with:
+          operation: open-or-update
+          image: ${{ inputs.source_repo }}
+          tag: ${{ matrix.tag }}
+          metadata-json: ${{ steps.find.outputs.metadata-json }}
+          token: ${{ github.token }}
+
+      - name: Notify Slack of blocked image
+        if: steps.find.outputs.blocked == 'true'
+        uses: ./.github/actions/notify-slack
+        with:
+          webhook-url: ${{ secrets.slack_webhook }}
+          status: blocked-pending
+          image: ${{ inputs.source_repo }}
+          tag: ${{ matrix.tag }}
+          threshold: ${{ inputs.severity_threshold }}
+          blocking-cves: ${{ steps.find.outputs.blocking-cves }}
+          issue-url: ${{ steps.issue.outputs.issue-url }}
+          run-url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
 
   # --- Phase 3: aggregate the per-tag results into one job summary. -----------
   summary:

--- a/.github/workflows/_promote-from-quarantine-sbom.yml
+++ b/.github/workflows/_promote-from-quarantine-sbom.yml
@@ -62,9 +62,17 @@ on:
         required: false
         default: false
         type: boolean
+      enable_approval:
+        description: "On a blocked image, post a Slack notification and open a promotion tracking issue for a manual approve/deny override."
+        required: false
+        default: false
+        type: boolean
     secrets:
       ghcr_delete_token:
         description: "PAT with delete:packages used to remove quarantine tags. Optional; deletion is skipped when absent."
+        required: false
+      slack_webhook:
+        description: "Slack incoming webhook URL for blocked-image notifications. Optional; notification is skipped when absent."
         required: false
 
 jobs:
@@ -137,6 +145,7 @@ jobs:
     permissions:
       contents: read
       packages: write
+      issues: write
     strategy:
       fail-fast: false
       matrix:
@@ -254,6 +263,67 @@ jobs:
           repository: ${{ inputs.source_repo }}
           tag: ${{ matrix.tag }}
           token: ${{ secrets.ghcr_delete_token }}
+
+      # When approval is enabled and the image is blocked (including a missing
+      # SBOM), build a machine-readable metadata block, open/refresh the
+      # tracking issue, and notify Slack for a manual approve/deny override.
+      - name: Build override metadata
+        id: meta
+        if: startsWith(steps.evaluate.outputs.decision, 'blocked') && inputs.enable_approval
+        env:
+          REMAINING_MD: "${{ steps.evaluate.outputs.remaining-md }}"
+        run: |
+          set -euo pipefail
+          export LC_ALL=C
+
+          digest="$(crane digest "${SOURCE_REPO}:${TAG}" 2>/dev/null || true)"
+
+          cves_json="$(printf '%s' "${REMAINING_MD}" | tr ',' '\n' \
+            | sed 's/^[[:space:]]*//; s/[[:space:]]*$//' \
+            | jq -R . | jq -sc 'map(select(length > 0))')"
+
+          meta="$(jq -nc \
+            --arg sr "${SOURCE_REPO}" \
+            --arg dr "${DEST_REPO}" \
+            --arg tag "${TAG}" \
+            --arg digest "${digest}" \
+            --arg th "${THRESHOLD}" \
+            --arg sv "${TRIVY_RESOLVED:-}" \
+            --arg pt "${SBOM_PREDICATE_TYPE}" \
+            --argjson cves "${cves_json}" \
+            '{source_repo:$sr, dest_repo:$dr, tag:$tag, digest:$digest,
+              threshold:$th, scanner:"trivy", scanner_version:$sv,
+              method:"sbom", sbom_predicate_type:$pt, blocking_cves:$cves}')"
+
+          {
+            echo "metadata-json<<CSSC_META_EOF"
+            printf '%s\n' "${meta}"
+            echo "CSSC_META_EOF"
+          } >> "${GITHUB_OUTPUT}"
+
+      - name: Open promotion tracking issue
+        id: issue
+        if: startsWith(steps.evaluate.outputs.decision, 'blocked') && inputs.enable_approval
+        uses: ./.github/actions/manage-issue
+        with:
+          operation: open-or-update
+          image: ${{ inputs.source_repo }}
+          tag: ${{ matrix.tag }}
+          metadata-json: ${{ steps.meta.outputs.metadata-json }}
+          token: ${{ github.token }}
+
+      - name: Notify Slack of blocked image
+        if: startsWith(steps.evaluate.outputs.decision, 'blocked') && inputs.enable_approval
+        uses: ./.github/actions/notify-slack
+        with:
+          webhook-url: ${{ secrets.slack_webhook }}
+          status: blocked-pending
+          image: ${{ inputs.source_repo }}
+          tag: ${{ matrix.tag }}
+          threshold: ${{ inputs.severity_threshold }}
+          blocking-cves: ${{ steps.evaluate.outputs.remaining-md }}
+          issue-url: ${{ steps.issue.outputs.issue-url }}
+          run-url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
 
       - name: Record result
         if: always()

--- a/.github/workflows/_promote-from-quarantine.yml
+++ b/.github/workflows/_promote-from-quarantine.yml
@@ -140,7 +140,6 @@ jobs:
     permissions:
       contents: read
       packages: write
-      issues: write
     strategy:
       fail-fast: false
       matrix:
@@ -258,11 +257,12 @@ jobs:
           tag: ${{ matrix.tag }}
           token: ${{ secrets.ghcr_delete_token }}
 
-      # When approval is enabled and the image is blocked, build a machine-
-      # readable metadata block (so a later override run can recover the
-      # promotion parameters), open/refresh the tracking issue, and notify Slack.
-      - name: Build override metadata
-        id: meta
+      # When approval is enabled and the image is blocked, persist a machine-
+      # readable metadata block alongside the per-tag result. The downstream
+      # `notify` job (which alone holds `issues: write`) reads it back to open
+      # the tracking issue and send the Slack alert, so this scan matrix never
+      # needs issue-write permission.
+      - name: Persist override metadata
         if: steps.evaluate.outputs.decision == 'blocked' && inputs.enable_approval
         env:
           DEST_REPO: "${{ inputs.dest_repo }}"
@@ -271,13 +271,17 @@ jobs:
           set -euo pipefail
           export LC_ALL=C
 
+          safe="${TAG//[^A-Za-z0-9_.-]/_}"
+          out="${RUNNER_TEMP}/result/${safe}"
+          mkdir -p "${out}"
+
           digest="$(crane digest "${SOURCE_REPO}:${TAG}" 2>/dev/null || true)"
 
           cves_json="$(printf '%s' "${REMAINING_MD}" | tr ',' '\n' \
             | sed 's/^[[:space:]]*//; s/[[:space:]]*$//' \
             | jq -R . | jq -sc 'map(select(length > 0))')"
 
-          meta="$(jq -nc \
+          jq -nc \
             --arg sr "${SOURCE_REPO}" \
             --arg dr "${DEST_REPO}" \
             --arg tag "${TAG}" \
@@ -287,37 +291,7 @@ jobs:
             --argjson cves "${cves_json}" \
             '{source_repo:$sr, dest_repo:$dr, tag:$tag, digest:$digest,
               threshold:$th, scanner:"trivy", scanner_version:$sv,
-              method:"image", blocking_cves:$cves}')"
-
-          {
-            echo "metadata-json<<CSSC_META_EOF"
-            printf '%s\n' "${meta}"
-            echo "CSSC_META_EOF"
-          } >> "${GITHUB_OUTPUT}"
-
-      - name: Open promotion tracking issue
-        id: issue
-        if: steps.evaluate.outputs.decision == 'blocked' && inputs.enable_approval
-        uses: ./.github/actions/manage-issue
-        with:
-          operation: open-or-update
-          image: ${{ inputs.source_repo }}
-          tag: ${{ matrix.tag }}
-          metadata-json: ${{ steps.meta.outputs.metadata-json }}
-          token: ${{ github.token }}
-
-      - name: Notify Slack of blocked image
-        if: steps.evaluate.outputs.decision == 'blocked' && inputs.enable_approval
-        uses: ./.github/actions/notify-slack
-        with:
-          webhook-url: ${{ secrets.slack_webhook }}
-          status: blocked-pending
-          image: ${{ inputs.source_repo }}
-          tag: ${{ matrix.tag }}
-          threshold: ${{ inputs.severity_threshold }}
-          blocking-cves: ${{ steps.evaluate.outputs.remaining-md }}
-          issue-url: ${{ steps.issue.outputs.issue-url }}
-          run-url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+              method:"image", blocking_cves:$cves}' > "${out}/override-metadata.json"
 
       # Render this tag's run log + result fragment and upload it for the summary
       # job to aggregate. Runs even if an earlier step failed so partial results
@@ -456,6 +430,83 @@ jobs:
           name: scan-result-${{ strategy.job-index }}
           path: ${{ runner.temp }}/result
           retention-days: 1
+
+  # --- Phase 2b: open tracking issues + notify Slack for blocked images. ------
+  # Split out from `scan` so that matrix never needs `issues: write`. Runs only
+  # when approval is enabled; matrixes over every tag and no-ops for any tag
+  # that the scan job did not flag as blocked (no override-metadata artifact).
+  notify:
+    needs: [enumerate, scan]
+    if: always() && inputs.enable_approval && needs.enumerate.outputs.has-tags == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+    strategy:
+      fail-fast: false
+      matrix:
+        tag: ${{ fromJSON(needs.enumerate.outputs.tags-json) }}
+    env:
+      SOURCE_REPO: "${{ inputs.source_repo }}"
+      TAG: "${{ matrix.tag }}"
+    steps:
+      - name: Check out actions
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+
+      - name: Download results
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          pattern: scan-result-*
+          path: ${{ runner.temp }}/results
+
+      - name: Locate override metadata for this tag
+        id: find
+        run: |
+          set -euo pipefail
+          export LC_ALL=C
+
+          safe="${TAG//[^A-Za-z0-9_.-]/_}"
+          meta_file="$(find "${RUNNER_TEMP}/results" -type f \
+            -path "*/${safe}/override-metadata.json" 2>/dev/null | head -n1 || true)"
+
+          if [ -z "${meta_file}" ] || [ ! -s "${meta_file}" ]; then
+            echo "blocked=false" >> "${GITHUB_OUTPUT}"
+            exit 0
+          fi
+
+          meta="$(jq -c . "${meta_file}")"
+          cves="$(printf '%s' "${meta}" | jq -r '(.blocking_cves // []) | join(", ")')"
+          echo "blocked=true" >> "${GITHUB_OUTPUT}"
+          echo "blocking-cves=${cves}" >> "${GITHUB_OUTPUT}"
+          {
+            echo "metadata-json<<CSSC_META_EOF"
+            printf '%s\n' "${meta}"
+            echo "CSSC_META_EOF"
+          } >> "${GITHUB_OUTPUT}"
+
+      - name: Open promotion tracking issue
+        id: issue
+        if: steps.find.outputs.blocked == 'true'
+        uses: ./.github/actions/manage-issue
+        with:
+          operation: open-or-update
+          image: ${{ inputs.source_repo }}
+          tag: ${{ matrix.tag }}
+          metadata-json: ${{ steps.find.outputs.metadata-json }}
+          token: ${{ github.token }}
+
+      - name: Notify Slack of blocked image
+        if: steps.find.outputs.blocked == 'true'
+        uses: ./.github/actions/notify-slack
+        with:
+          webhook-url: ${{ secrets.slack_webhook }}
+          status: blocked-pending
+          image: ${{ inputs.source_repo }}
+          tag: ${{ matrix.tag }}
+          threshold: ${{ inputs.severity_threshold }}
+          blocking-cves: ${{ steps.find.outputs.blocking-cves }}
+          issue-url: ${{ steps.issue.outputs.issue-url }}
+          run-url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
 
   # --- Phase 3: aggregate the per-tag results into one job summary. -----------
   summary:

--- a/.github/workflows/_promote-from-quarantine.yml
+++ b/.github/workflows/_promote-from-quarantine.yml
@@ -58,9 +58,17 @@ on:
         required: false
         default: false
         type: boolean
+      enable_approval:
+        description: "On a blocked image, post a Slack notification and open a promotion tracking issue for a manual approve/deny override."
+        required: false
+        default: false
+        type: boolean
     secrets:
       ghcr_delete_token:
         description: "PAT with delete:packages used to remove quarantine tags. Optional; deletion is skipped when absent."
+        required: false
+      slack_webhook:
+        description: "Slack incoming webhook URL for blocked-image notifications. Optional; notification is skipped when absent."
         required: false
 
 jobs:
@@ -132,6 +140,7 @@ jobs:
     permissions:
       contents: read
       packages: write
+      issues: write
     strategy:
       fail-fast: false
       matrix:
@@ -248,6 +257,67 @@ jobs:
           repository: ${{ inputs.source_repo }}
           tag: ${{ matrix.tag }}
           token: ${{ secrets.ghcr_delete_token }}
+
+      # When approval is enabled and the image is blocked, build a machine-
+      # readable metadata block (so a later override run can recover the
+      # promotion parameters), open/refresh the tracking issue, and notify Slack.
+      - name: Build override metadata
+        id: meta
+        if: steps.evaluate.outputs.decision == 'blocked' && inputs.enable_approval
+        env:
+          DEST_REPO: "${{ inputs.dest_repo }}"
+          REMAINING_MD: "${{ steps.evaluate.outputs.remaining-md }}"
+        run: |
+          set -euo pipefail
+          export LC_ALL=C
+
+          digest="$(crane digest "${SOURCE_REPO}:${TAG}" 2>/dev/null || true)"
+
+          cves_json="$(printf '%s' "${REMAINING_MD}" | tr ',' '\n' \
+            | sed 's/^[[:space:]]*//; s/[[:space:]]*$//' \
+            | jq -R . | jq -sc 'map(select(length > 0))')"
+
+          meta="$(jq -nc \
+            --arg sr "${SOURCE_REPO}" \
+            --arg dr "${DEST_REPO}" \
+            --arg tag "${TAG}" \
+            --arg digest "${digest}" \
+            --arg th "${THRESHOLD}" \
+            --arg sv "${TRIVY_RESOLVED:-}" \
+            --argjson cves "${cves_json}" \
+            '{source_repo:$sr, dest_repo:$dr, tag:$tag, digest:$digest,
+              threshold:$th, scanner:"trivy", scanner_version:$sv,
+              method:"image", blocking_cves:$cves}')"
+
+          {
+            echo "metadata-json<<CSSC_META_EOF"
+            printf '%s\n' "${meta}"
+            echo "CSSC_META_EOF"
+          } >> "${GITHUB_OUTPUT}"
+
+      - name: Open promotion tracking issue
+        id: issue
+        if: steps.evaluate.outputs.decision == 'blocked' && inputs.enable_approval
+        uses: ./.github/actions/manage-issue
+        with:
+          operation: open-or-update
+          image: ${{ inputs.source_repo }}
+          tag: ${{ matrix.tag }}
+          metadata-json: ${{ steps.meta.outputs.metadata-json }}
+          token: ${{ github.token }}
+
+      - name: Notify Slack of blocked image
+        if: steps.evaluate.outputs.decision == 'blocked' && inputs.enable_approval
+        uses: ./.github/actions/notify-slack
+        with:
+          webhook-url: ${{ secrets.slack_webhook }}
+          status: blocked-pending
+          image: ${{ inputs.source_repo }}
+          tag: ${{ matrix.tag }}
+          threshold: ${{ inputs.severity_threshold }}
+          blocking-cves: ${{ steps.evaluate.outputs.remaining-md }}
+          issue-url: ${{ steps.issue.outputs.issue-url }}
+          run-url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
 
       # Render this tag's run log + result fragment and upload it for the summary
       # job to aggregate. Runs even if an earlier step failed so partial results

--- a/.github/workflows/_promote-override.yml
+++ b/.github/workflows/_promote-override.yml
@@ -1,0 +1,239 @@
+# Reusable workflow: act on a manual promotion-override decision.
+#
+# This workflow is internal (note the leading underscore) and is called by the
+# `promote-override.yml` caller via `uses:`. It performs the override decision
+# for one quarantined image+tag whose promotion was blocked by the vulnerability
+# gate and is being approved or denied by a maintainer.
+#
+# Flow:
+#   1. verify-approver  — confirm the approver has sufficient repo permission.
+#   2. manage-issue get — recover the promotion metadata recorded on the issue.
+#   3. approve: mirror-image (force) -> attach-scan-report (override annotations)
+#      -> delete-image (optional) -> manage-issue close (promotion-approved)
+#      -> notify-slack (approved).
+#   4. deny: manage-issue close (promotion-denied) -> notify-slack (denied).
+#
+# Terminology and the action catalogue: see docs/reference/workflow-actions.md.
+# See also docs/architecture/workflows/promote-from-quarantine-override-approval.md.
+name: _reusable / promote-override
+
+on:
+  workflow_call:
+    inputs:
+      issue_number:
+        description: "Tracking-issue number carrying the promotion metadata."
+        required: true
+        type: string
+      decision:
+        description: "approve | deny."
+        required: true
+        type: string
+      approver:
+        description: "Login that issued the decision."
+        required: true
+        type: string
+      min_permission:
+        description: "Minimum repo permission required to approve: admin | maintain | write."
+        required: false
+        default: maintain
+        type: string
+      delete_source:
+        description: "Delete the tag from quarantine after a successful override promotion."
+        required: false
+        default: true
+        type: boolean
+      trivy_version:
+        description: "Trivy version to install; also recorded in the referrer when missing from metadata."
+        required: false
+        default: v0.71.0
+        type: string
+    secrets:
+      ghcr_delete_token:
+        description: "PAT with delete:packages used to remove the quarantine tag. Optional."
+        required: false
+      slack_webhook:
+        description: "Slack incoming webhook URL for the decision notification. Optional."
+        required: false
+
+jobs:
+  override:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      issues: write
+    env:
+      DECISION: "${{ inputs.decision }}"
+      APPROVER: "${{ inputs.approver }}"
+      ISSUE_NUMBER: "${{ inputs.issue_number }}"
+    steps:
+      - name: Validate decision
+        run: |
+          set -euo pipefail
+          case "${DECISION}" in
+            approve|deny) : ;;
+            *) echo "::error::Invalid decision '${DECISION}' (expected approve|deny)"; exit 1 ;;
+          esac
+
+      - name: Check out actions
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+
+      # An approval bypasses the security gate, so the approver must hold a
+      # sufficient repository role. A denial is harmless and does not require it.
+      - name: Verify approver
+        if: inputs.decision == 'approve'
+        uses: ./.github/actions/verify-approver
+        with:
+          actor: ${{ inputs.approver }}
+          min-permission: ${{ inputs.min_permission }}
+          token: ${{ github.token }}
+
+      - name: Read promotion metadata
+        id: issue
+        uses: ./.github/actions/manage-issue
+        with:
+          operation: get
+          image: "unused"
+          tag: "unused"
+          issue-number: ${{ inputs.issue_number }}
+          token: ${{ github.token }}
+
+      # Unpack the recovered JSON metadata into step outputs the later steps use.
+      - name: Parse metadata
+        id: meta
+        env:
+          METADATA_JSON: "${{ steps.issue.outputs.metadata-json }}"
+        run: |
+          set -euo pipefail
+          export LC_ALL=C
+
+          if [ -z "${METADATA_JSON}" ] || ! printf '%s' "${METADATA_JSON}" | jq -e . >/dev/null 2>&1; then
+            echo "::error::No valid promotion metadata found on issue #${ISSUE_NUMBER}."
+            exit 1
+          fi
+
+          get () { printf '%s' "${METADATA_JSON}" | jq -r "$1 // empty"; }
+
+          {
+            echo "source-repo=$(get '.source_repo')"
+            echo "dest-repo=$(get '.dest_repo')"
+            echo "tag=$(get '.tag')"
+            echo "threshold=$(get '.threshold')"
+            echo "method=$(get '.method')"
+            echo "scanner-version=$(get '.scanner_version')"
+            # Pipe-join the blocking CVE array for the referrer annotation.
+            echo "cves=$(printf '%s' "${METADATA_JSON}" | jq -r '(.blocking_cves // []) | join("|")')"
+            # SBOM promotions must carry referrers along.
+            if [ "$(get '.method')" = "sbom" ]; then
+              echo "copy-referrers=true"
+            else
+              echo "copy-referrers=false"
+            fi
+          }  >> "${GITHUB_OUTPUT}"
+
+      - name: Set up crane
+        if: inputs.decision == 'approve'
+        uses: imjasonh/setup-crane@31b88efe9de28ae0ffa220711af4b60be9435f6e # v0.4
+
+      - name: Set up oras
+        if: inputs.decision == 'approve'
+        uses: oras-project/setup-oras@38de303aac69abb66f3e6255b7198bff35f323e3 # v2.0.0
+        with:
+          version: 1.3.1
+
+      - name: Log in to GHCR
+        if: inputs.decision == 'approve'
+        uses: ./.github/actions/registry-login
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ github.token }}
+          with-oras: "true"
+
+      # --- Approve path: promote despite the gate, record the override. --------
+      - name: Promote overridden image
+        if: inputs.decision == 'approve'
+        uses: ./.github/actions/mirror-image
+        with:
+          source-image: ${{ steps.meta.outputs.source-repo }}
+          source-tag: ${{ steps.meta.outputs.tag }}
+          dest-image: ${{ steps.meta.outputs.dest-repo }}
+          dest-tag: ${{ steps.meta.outputs.tag }}
+          force: "true"
+          copy-referrers: ${{ steps.meta.outputs.copy-referrers }}
+
+      - name: Attach scan-report attestation
+        if: inputs.decision == 'approve'
+        uses: ./.github/actions/attach-scan-report
+        with:
+          image-ref: ${{ steps.meta.outputs.dest-repo }}:${{ steps.meta.outputs.tag }}
+          source-repo: ${{ steps.meta.outputs.source-repo }}
+          tag: ${{ steps.meta.outputs.tag }}
+          threshold: ${{ steps.meta.outputs.threshold }}
+          scanner-version: ${{ steps.meta.outputs.scanner-version }}
+          method: ${{ steps.meta.outputs.method }}
+          override: "true"
+          override-approver: ${{ inputs.approver }}
+          override-issue: ${{ steps.issue.outputs.issue-url }}
+          override-cves: ${{ steps.meta.outputs.cves }}
+
+      - name: Delete overridden tag from quarantine
+        if: inputs.decision == 'approve' && inputs.delete_source
+        uses: ./.github/actions/delete-image
+        with:
+          repository: ${{ steps.meta.outputs.source-repo }}
+          tag: ${{ steps.meta.outputs.tag }}
+          token: ${{ secrets.ghcr_delete_token }}
+
+      - name: Close issue as approved
+        if: inputs.decision == 'approve'
+        uses: ./.github/actions/manage-issue
+        with:
+          operation: close
+          image: ${{ steps.meta.outputs.source-repo }}
+          tag: ${{ steps.meta.outputs.tag }}
+          issue-number: ${{ inputs.issue_number }}
+          outcome: promotion-approved
+          body: "Override **approved** by @${{ inputs.approver }}. Image promoted to `${{ steps.meta.outputs.dest-repo }}:${{ steps.meta.outputs.tag }}` despite the failing gate. ([run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}))"
+          token: ${{ github.token }}
+
+      - name: Notify Slack of approval
+        if: inputs.decision == 'approve'
+        uses: ./.github/actions/notify-slack
+        with:
+          webhook-url: ${{ secrets.slack_webhook }}
+          status: approved
+          image: ${{ steps.meta.outputs.source-repo }}
+          tag: ${{ steps.meta.outputs.tag }}
+          threshold: ${{ steps.meta.outputs.threshold }}
+          blocking-cves: ${{ steps.meta.outputs.cves }}
+          issue-url: ${{ steps.issue.outputs.issue-url }}
+          run-url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          approver: ${{ inputs.approver }}
+
+      # --- Deny path: no promotion; close and notify. --------------------------
+      - name: Close issue as denied
+        if: inputs.decision == 'deny'
+        uses: ./.github/actions/manage-issue
+        with:
+          operation: close
+          image: ${{ steps.meta.outputs.source-repo }}
+          tag: ${{ steps.meta.outputs.tag }}
+          issue-number: ${{ inputs.issue_number }}
+          outcome: promotion-denied
+          body: "Override **denied** by @${{ inputs.approver }}. `${{ steps.meta.outputs.source-repo }}:${{ steps.meta.outputs.tag }}` stays in quarantine."
+          token: ${{ github.token }}
+
+      - name: Notify Slack of denial
+        if: inputs.decision == 'deny'
+        uses: ./.github/actions/notify-slack
+        with:
+          webhook-url: ${{ secrets.slack_webhook }}
+          status: denied
+          image: ${{ steps.meta.outputs.source-repo }}
+          tag: ${{ steps.meta.outputs.tag }}
+          threshold: ${{ steps.meta.outputs.threshold }}
+          blocking-cves: ${{ steps.meta.outputs.cves }}
+          issue-url: ${{ steps.issue.outputs.issue-url }}
+          run-url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          approver: ${{ inputs.approver }}

--- a/.github/workflows/promote-override.yml
+++ b/.github/workflows/promote-override.yml
@@ -1,0 +1,93 @@
+# Caller workflow: promote-override
+#
+# Wires triggers to the reusable `_promote-override.yml` workflow. A maintainer
+# approves or denies the promotion of a quarantined image that failed the
+# vulnerability gate, either by commenting `/approve` or `/deny` on the tracking
+# issue (which the GitHub Slack app also surfaces), or via a manual dispatch.
+#
+# The issue_comment trigger always runs the workflow definition from the default
+# branch, so the parsing/promotion logic cannot be tampered with from elsewhere;
+# the override itself is still gated by `verify-approver` inside the reusable
+# workflow.
+#
+# See docs/architecture/workflows/promote-from-quarantine-override-approval.md.
+name: promote override
+
+on:
+  issue_comment:
+    types: [created]
+  workflow_dispatch:
+    inputs:
+      issue_number:
+        description: "Tracking-issue number to act on."
+        required: true
+        type: string
+      decision:
+        description: "approve | deny."
+        required: true
+        type: choice
+        options: [approve, deny]
+
+permissions:
+  contents: read
+  packages: write
+  issues: write
+
+concurrency:
+  group: promote-override-${{ github.event.issue.number || github.event.inputs.issue_number }}
+  cancel-in-progress: false
+
+jobs:
+  # Parse an issue comment into an override decision. Only runs for comments on
+  # open issues carrying the promotion-pending label.
+  parse:
+    if: >-
+      github.event_name == 'issue_comment' &&
+      github.event.issue.state == 'open' &&
+      contains(github.event.issue.labels.*.name, 'promotion-pending')
+    runs-on: ubuntu-latest
+    outputs:
+      decision: ${{ steps.parse.outputs.decision }}
+    steps:
+      - name: Parse command
+        id: parse
+        env:
+          COMMENT_BODY: "${{ github.event.comment.body }}"
+        run: |
+          set -euo pipefail
+          export LC_ALL=C
+
+          # Accept a leading /approve or /deny as the command (first token).
+          first="$(printf '%s' "${COMMENT_BODY}" | tr -d '\r' | awk 'NR==1{print $1}')"
+          case "${first}" in
+            /approve) decision="approve" ;;
+            /deny)    decision="deny" ;;
+            *)        decision="" ;;
+          esac
+          if [ -z "${decision}" ]; then
+            echo "No /approve or /deny command found; nothing to do."
+          fi
+          echo "decision=${decision}" >> "${GITHUB_OUTPUT}"
+
+  from-comment:
+    needs: parse
+    if: needs.parse.outputs.decision != ''
+    uses: ./.github/workflows/_promote-override.yml
+    with:
+      issue_number: ${{ github.event.issue.number }}
+      decision: ${{ needs.parse.outputs.decision }}
+      approver: ${{ github.event.comment.user.login }}
+    secrets:
+      slack_webhook: ${{ secrets.SLACK_WEBHOOK }}
+      ghcr_delete_token: ${{ secrets.GHCR_DELETE_TOKEN }}
+
+  from-dispatch:
+    if: github.event_name == 'workflow_dispatch'
+    uses: ./.github/workflows/_promote-override.yml
+    with:
+      issue_number: ${{ github.event.inputs.issue_number }}
+      decision: ${{ github.event.inputs.decision }}
+      approver: ${{ github.actor }}
+    secrets:
+      slack_webhook: ${{ secrets.SLACK_WEBHOOK }}
+      ghcr_delete_token: ${{ secrets.GHCR_DELETE_TOKEN }}

--- a/docs/architecture/workflows/promote-from-quarantine-override-approval.md
+++ b/docs/architecture/workflows/promote-from-quarantine-override-approval.md
@@ -1,0 +1,271 @@
+# Design proposal: human-in-the-loop override approval for blocked images
+
+**Status:** Approved — implemented (see tracking issue #64)
+**Scope:** Adds an optional manual-approval path that lets an authorized
+maintainer promote a `quarantine/<image>` tag **despite** it failing the
+vulnerability gate, with Slack notification and a GitHub issue as the audit
+trail. Builds on the
+[promote-from-quarantine workflows](promote-from-quarantine-workflows.md).
+
+---
+
+## 1. Problem statement
+
+Today the promote-from-quarantine workflows scan each quarantine tag, apply a
+severity threshold plus a CVE exception list, and **silently leave blocked
+images in quarantine** — surfacing the outcome only in the run status and job
+summary. There is no notification and no way to *consciously override* the gate
+for a specific image without editing the exception list and re-running.
+
+We want a deliberate, audited override path:
+
+1. The scan-and-promote workflow runs.
+2. A scanned image fails the threshold and is **blocked**.
+3. The maintainer is **notified via Slack**, and a **GitHub issue is filed** for
+   that image+tag.
+4. The maintainer **approves or denies** the promotion.
+5. **Deny** → no promotion; the issue is **closed** with the denial recorded.
+6. **Approve** → the image is **promoted despite the failing gate**, the issue is
+   closed as approved, and the promotion is recorded as a manual override in the
+   image's provenance.
+
+## 2. Decisions
+
+| Decision | Choice | Rationale |
+| -------- | ------ | --------- |
+| Approval mechanism | **Two-workflow split** | Scan run ends green and holds no runner; the override can be approved hours or days later by a separate, decoupled workflow. |
+| Granularity | **Per image+tag** | One tracking issue and one approve/deny decision per blocked tag, matching the existing per-tag matrix model. |
+| Repo visibility | Public | No plan limitation; chosen path does not depend on environment required-reviewers. |
+| Slack | **GitHub Slack app** for interaction + a reusable `notify-slack` action for rich custom alerts | The GitHub Slack app surfaces the tracking issue in Slack and supports commenting/closing from Slack; the action posts a formatted CVE alert. |
+
+### 2.1 Approval surface (important)
+
+The GitHub Slack app's **one-click approval button** is a feature of
+**environment protection rules**, which the two-workflow split does *not* use.
+With the split, the approval surface is an **issue-comment command** on the
+per-tag tracking issue:
+
+- Comment **`/approve`** to promote the image despite the failing gate.
+- Comment **`/deny`** to reject the promotion and close the issue.
+
+These comments can be posted from the GitHub web UI, GitHub mobile, **or from
+Slack** via the GitHub Slack app's issue-comment support. If one-click Slack
+approval buttons become a hard requirement later, switching the override gate to
+a **GitHub Environment + required reviewers** is the migration path (noted in
+section 7).
+
+## 3. Architecture
+
+The design follows the established **caller + reusable workflow + composite
+action** pattern. Two new **reusable composite actions** are added for Slack and
+issue handling, one for approver verification, and a new **reusable
+override workflow** with a thin caller is introduced. The existing scan
+workflows are extended (backward-compatibly) to fire the notification and open
+the issue when an image is blocked.
+
+```mermaid
+flowchart TD
+  subgraph W1["Workflow 1 — scan & promote (existing, extended)"]
+    E[enumerate] --> S["scan (matrix per tag): scan + gate"]
+    S -->|decision=promote| AP[auto-promote, attach report, cleanup]
+    S -->|decision=blocked & enable_approval| N["notify-slack (blocked-pending)<br/>+ manage-issue (open-or-update)"]
+  end
+
+  N -. "files per-tag issue, labeled promotion-pending with metadata block" .-> ISSUE[(Tracking issue)]
+  ISSUE -. "surfaced in Slack via GitHub Slack app" .-> SLACK[(Slack channel)]
+
+  subgraph W2["Workflow 2 — promote-override (new)"]
+    T["trigger: issue_comment /approve or /deny<br/>(also workflow_dispatch)"] --> V[verify-approver]
+    V -->|/approve| PR["mirror-image (force) + attach-scan-report (override annotations)<br/>+ delete-image (optional)"]
+    PR --> CA["manage-issue close (promotion-approved)<br/>+ notify-slack (approved)"]
+    V -->|/deny| CD["manage-issue close (promotion-denied)<br/>+ notify-slack (denied)"]
+  end
+
+  ISSUE --> T
+```
+
+### 3.1 The tracking issue is the source of truth
+
+Because Workflow 2 may run long after Workflow 1 (in a separate run with no
+shared state), all data needed to promote later is embedded in the issue body as
+a **machine-readable fenced metadata block** (JSON), e.g.:
+
+```json
+{
+  "source_repo": "ghcr.io/toddysm/quarantine/python",
+  "dest_repo": "ghcr.io/toddysm/golden/python",
+  "tag": "3.14-slim",
+  "digest": "sha256:...",
+  "threshold": "HIGH",
+  "scanner": "trivy",
+  "scanner_version": "0.71.0",
+  "method": "image",
+  "blocking_cves": ["CVE-2024-1234", "CVE-2024-5678"]
+}
+```
+
+Workflow 2 reads this block back from the issue, so the issue is the single
+source of truth for the override. Reruns of the scan workflow update the same
+issue (deduped by label + deterministic title) instead of opening duplicates.
+
+## 4. New reusable composite actions (`.github/actions/<verb-noun>/`)
+
+These are the reusable building blocks (you asked specifically for reusable
+actions). Each is a single-purpose composite action consistent with the existing
+catalogue.
+
+### 4.1 `notify-slack`
+Posts a formatted (Block Kit) message to a Slack **incoming webhook**.
+
+| Input | Required | Description |
+| ----- | -------- | ----------- |
+| `webhook-url` | yes | Slack incoming webhook URL (passed from the `slack_webhook` secret). |
+| `status` | yes | `blocked-pending` \| `approved` \| `denied`. Selects the message template. |
+| `image` | yes | Source repository (e.g. `ghcr.io/toddysm/quarantine/python`). |
+| `tag` | yes | Image tag. |
+| `threshold` | no | Severity threshold the image failed. |
+| `blocking-cves` | no | Comma/space-separated CVE summary for the alert. |
+| `issue-url` | no | Link to the tracking issue. |
+| `run-url` | no | Link to the workflow run. |
+| `approver` | no | Actor recorded for approved/denied messages. |
+
+### 4.2 `manage-issue`
+Wraps issue lifecycle operations via the GitHub REST API (`gh`/`GITHUB_TOKEN`,
+`issues: write`).
+
+| Input | Required | Description |
+| ----- | -------- | ----------- |
+| `operation` | yes | `open-or-update` \| `comment` \| `close`. |
+| `image` | yes | Source repository (used for dedupe + metadata). |
+| `tag` | yes | Image tag (used for dedupe + metadata). |
+| `metadata-json` | for `open-or-update` | The machine-readable block embedded in the body. |
+| `body` / `comment` | no | Human-readable body or comment text. |
+| `outcome` | for `close` | `promotion-approved` \| `promotion-denied` (sets the closing label + comment). |
+| `token` | yes | `GITHUB_TOKEN`. |
+
+Behavior:
+- **`open-or-update`** — idempotent. Dedupes by label `promotion-pending` plus a
+  deterministic title (`Promotion blocked: <image>:<tag>`); creates the issue if
+  none exists, otherwise updates the body/metadata and adds a comment. Applies
+  labels `promotion-pending`, `image:<repo>`, `tag:<tag>`.
+- **`comment`** — appends a comment.
+- **`close`** — removes `promotion-pending`, applies the outcome label, posts a
+  closing comment, and closes the issue.
+
+Outputs: `issue-number`, `issue-url`, and (for the override workflow)
+`metadata-json` parsed back out of an existing issue.
+
+### 4.3 `verify-approver`
+Security control. Confirms the commenter/actor has sufficient repository
+permission before an override is honored.
+
+| Input | Required | Description |
+| ----- | -------- | ----------- |
+| `actor` | yes | The login that issued the command. |
+| `min-permission` | no | Minimum permission (default `maintain`; `admin`/`maintain`/`write`). |
+| `token` | yes | `GITHUB_TOKEN`. |
+
+Calls `GET /repos/{owner}/{repo}/collaborators/{actor}/permission` and fails the
+step (sets output `authorized=false`) if the actor is below the threshold.
+
+### 4.4 Extended action: `attach-scan-report`
+Add override-provenance annotations so a promoted-despite-failing image carries
+auditable proof. New optional inputs produce new annotations on the scan-report
+referrer:
+
+| Annotation | Example | Meaning |
+| ---------- | ------- | ------- |
+| `com.cssc.scan.override` | `true` | Image was promoted via manual override. |
+| `com.cssc.scan.override-approver` | `toddysm` | Login that approved. |
+| `com.cssc.scan.override-issue` | `https://github.com/.../issues/42` | Tracking issue. |
+| `com.cssc.scan.override-cves` | `CVE-2024-1234\|CVE-2024-5678` | CVEs that were overridden. |
+
+## 5. New / changed workflows
+
+### 5.1 Extended — `_promote-from-quarantine.yml` and `_promote-from-quarantine-sbom.yml`
+Backward-compatible additions:
+
+- New inputs: `enable_approval` (bool, default `false`),
+  and the existing severity/exception inputs unchanged.
+- New optional secret: `slack_webhook`.
+- In the `scan` job, when `enable_approval == true` and a tag's
+  `decision == blocked`, run `notify-slack` (status `blocked-pending`) and
+  `manage-issue` (`open-or-update`) with the metadata block. No behavior change
+  when `enable_approval` is `false` — existing callers are unaffected.
+
+### 5.2 New reusable — `_promote-override.yml`
+Performs the override promotion for a single image+tag.
+
+Inputs: `source_repo`, `dest_repo`, `tag`, `issue_number`, `approver`,
+`decision` (`approve`/`deny`), `trivy_version`, `method` (`image`/`sbom`).
+Secret: `slack_webhook`, optional `ghcr_delete_token`.
+
+Jobs/steps:
+1. `verify-approver` — abort if the approver lacks permission.
+2. On **approve**: `manage-issue` (read metadata) → `mirror-image` (`force: true`,
+   `oras cp -r` for SBOM method) → `attach-scan-report` (override annotations) →
+   `delete-image` (optional) → `manage-issue close` (`promotion-approved`) →
+   `notify-slack` (approved).
+3. On **deny**: `manage-issue close` (`promotion-denied`) → `notify-slack`
+   (denied). No promotion.
+
+### 5.3 New caller — `promote-override.yml`
+Thin caller wiring triggers to `_promote-override.yml`.
+
+- **Triggers:**
+  - `issue_comment` (type `created`) — fires when a comment is added to an issue
+    labeled `promotion-pending`. A small parse step extracts `/approve` or
+    `/deny` and the image+tag from the issue, then calls the reusable workflow.
+    (Runs the default-branch version of the workflow, so it is not
+    attacker-controlled.)
+  - `workflow_dispatch` — manual fallback: `image`, `tag`, `decision`.
+- **Permissions:** `contents: read`, `packages: write`, `issues: write`.
+- Forwards `slack_webhook` and `ghcr_delete_token` secrets.
+
+## 6. Caller impact
+
+Existing `promote-from-quarantine-<image>.yml` callers keep working unchanged.
+To opt in to approvals, a caller sets `enable_approval: true` and passes the
+`slack_webhook` secret. The new `promote-override.yml` is a single
+repository-wide caller (one issue-comment listener), not per image.
+
+## 7. Security considerations
+
+- **Privileged override.** Promoting a failing image bypasses the security gate,
+  so the override is gated by `verify-approver` (default `maintain`+). Anyone can
+  comment, but only authorized logins are honored.
+- **Trusted trigger.** `issue_comment` runs the workflow definition from the
+  default branch, not from a PR branch, preventing workflow tampering.
+- **Auditability.** Every override is recorded in (a) the closed issue, (b) the
+  Slack channel, and (c) the image's scan-report referrer annotations.
+- **Secret handling.** The Slack webhook is a repository/organization secret.
+- **Migration to environments.** If native one-click Slack approval (or stronger
+  audited gating) is later required, the override job can adopt a **GitHub
+  Environment with required reviewers**; the `notify-slack`/`manage-issue`
+  actions and the override-provenance annotations carry over unchanged.
+
+## 8. Out of scope (unchanged)
+
+No signing, no automatic remediation, no cross-scanner support, no `golden/`
+retention policy. This proposal only adds the notify + approve/deny override
+path.
+
+## 9. Deliverables summary (for approval)
+
+**Reusable composite actions**
+- `notify-slack` (new)
+- `manage-issue` (new)
+- `verify-approver` (new)
+- `attach-scan-report` (extended with override annotations)
+
+**Workflows**
+- `_promote-from-quarantine.yml` (extended: notify + open issue on block)
+- `_promote-from-quarantine-sbom.yml` (extended: same)
+- `_promote-override.yml` (new reusable override workflow)
+- `promote-override.yml` (new caller: issue-comment + manual triggers)
+
+**Docs**
+- This design doc; on implementation, update
+  [promote-from-quarantine-workflows.md](promote-from-quarantine-workflows.md),
+  [workflow-actions.md](../../reference/workflow-actions.md), and
+  [workflow-naming.md](../../contributing/workflow-naming.md).

--- a/docs/architecture/workflows/promote-from-quarantine-override-approval.md
+++ b/docs/architecture/workflows/promote-from-quarantine-override-approval.md
@@ -188,10 +188,13 @@ Backward-compatible additions:
 - New inputs: `enable_approval` (bool, default `false`),
   and the existing severity/exception inputs unchanged.
 - New optional secret: `slack_webhook`.
-- In the `scan` job, when `enable_approval == true` and a tag's
-  `decision == blocked`, run `notify-slack` (status `blocked-pending`) and
-  `manage-issue` (`open-or-update`) with the metadata block. No behavior change
-  when `enable_approval` is `false` — existing callers are unaffected.
+- When `enable_approval == true` and a tag's `decision == blocked`, the
+  `scan` job persists the override metadata block as a per-tag artifact (it
+  does **not** itself open issues). A dedicated `notify` job — the only job
+  granted `issues: write` — then reads that artifact and runs `manage-issue`
+  (`open-or-update`) and `notify-slack` (status `blocked-pending`). Keeping
+  `issues: write` off the `scan` matrix preserves least privilege. No behavior
+  change when `enable_approval` is `false` — existing callers are unaffected.
 
 ### 5.2 New reusable — `_promote-override.yml`
 Performs the override promotion for a single image+tag.

--- a/docs/architecture/workflows/promote-from-quarantine-workflows.md
+++ b/docs/architecture/workflows/promote-from-quarantine-workflows.md
@@ -315,8 +315,12 @@ The workflow therefore treats deletion as configurable:
 - **No cross-scanner support.** Trivy is the only scanner; the referrer schema
   records the scanner name/version to allow future additions.
 - **No retention policy for `golden/`.** Superseded golden tags are not pruned.
-- **No notification/alerting.** Failures and blocked images surface only through
-  the normal GitHub Actions run status and the job summary.
+- **No notification/alerting by default.** Failures and blocked images surface
+  through the normal GitHub Actions run status and the job summary. An *optional*
+  approval path (`enable_approval`) adds Slack notifications and a GitHub
+  tracking issue for blocked images, with a maintainer-driven `/approve` `/deny`
+  override; see
+  [override-approval design](promote-from-quarantine-override-approval.md).
 
 ## Adding a new promote-from-quarantine workflow
 

--- a/docs/contributing/workflow-naming.md
+++ b/docs/contributing/workflow-naming.md
@@ -13,13 +13,14 @@ both in the file system and in the Actions UI.
 | **Mirror** | Copy / refresh a base image from an upstream registry into GHCR | `mirror-<image>.yml` | `mirror / quarantine/<image>` | `mirror-quarantine-<image>` |
 | **Promote from quarantine** | Scan a quarantined image and promote it into its golden/base repository (`golden/<image>`, or `base/...` for base/hardened images) when it passes the vulnerability policy | `promote-from-quarantine-<image>.yml` | `promote from quarantine / quarantine/<image>` | `promote-from-quarantine-<image>` |
 | **Build** | Build an application image on top of a mirrored base | `build-<app>.yml` | `build / <app>` | `build-<app>` |
+| **Promote override** | Act on a maintainer's approve/deny of a blocked image (issue-comment or dispatch) | `promote-override.yml` | `promote override` | `promote-override-<issue>` |
 | **Reusable** | Shared logic invoked by other workflows; never triggered directly | `_<purpose>.yml` (leading underscore) | `_reusable / <purpose>` | n/a |
 | **Composite action** | A single reusable step shared across workflows | `.github/actions/<verb-noun>/action.yml` | `name: <verb-noun>` | n/a |
 
 ### Rules
 
 1. **Verb prefix.** Every workflow filename starts with a category verb:
-   `mirror-`, `promote-from-quarantine-`, `build-`, or a leading underscore
+   `mirror-`, `promote-from-quarantine-`, `promote-override`, `build-`, or a leading underscore
    (`_`) for reusable
    workflows. This groups related workflows together alphabetically and makes
    intent obvious at a glance.

--- a/docs/reference/workflow-actions.md
+++ b/docs/reference/workflow-actions.md
@@ -1,7 +1,7 @@
 # Workflow actions and terminology
 
 This repository's GitHub Actions are built from small, single-purpose
-**composite actions** under [`.github/actions/`](../../.github/actions/). The
+__composite actions__ under [`.github/actions/`](../../.github/actions/). The
 reusable workflows (`_*.yml`) orchestrate these actions; the per-image callers
 (`mirror-*.yml`, `scan-*.yml`) only supply configuration.
 
@@ -22,16 +22,16 @@ phrasings it replaces.
 
 | Canonical term | Meaning | Replaces |
 | -------------- | ------- | -------- |
-| **registry-login** | Authenticate the local clients to a registry. | "Log in to GHCR", "Log in to source registry" |
-| **enumerate-tags** | List the tags in a repository. | "Enumerate quarantine tags", "list tags" |
-| **mirror-image** | Idempotently copy one image between registries (digest-compare + copy). | "compare digests and copy", "crane copy" |
-| **promote-image** | Copy a passing image from quarantine into golden/base. Implemented as **mirror-image** with `force: true`. | "promote", "promote passing images" |
-| **copy-referrers** | Copy an image together with its OCI referrers (`oras cp -r` + per-platform children). Folded into **mirror-image** via `copy-referrers: true`. | "copy_referrers", "copy with referrers" |
-| **scan-image** | Scan one image filesystem with `trivy image`. | "scan images with Trivy" |
-| **scan-sbom** | Scan one image's per-platform SBOM attestations with `trivy sbom`. | "scan platform SBOMs" |
-| **evaluate-findings** | Apply the severity threshold + CVE exceptions to produce a gate decision. | "gate on scan findings" |
-| **attach-scan-report** | Attach the OCI scan-report referrer to a promoted image. | "attach scan-report attestation" |
-| **delete-image** | Delete one tag from a GHCR repository via the Packages API. | "delete promoted tags from quarantine" |
+| __registry-login__ | Authenticate the local clients to a registry. | "Log in to GHCR", "Log in to source registry" |
+| __enumerate-tags__ | List the tags in a repository. | "Enumerate quarantine tags", "list tags" |
+| __mirror-image__ | Idempotently copy one image between registries (digest-compare + copy). | "compare digests and copy", "crane copy" |
+| __promote-image__ | Copy a passing image from quarantine into golden/base. Implemented as __mirror-image__ with `force: true`. | "promote", "promote passing images" |
+| __copy-referrers__ | Copy an image together with its OCI referrers (`oras cp -r` + per-platform children). Folded into __mirror-image__ via `copy-referrers: true`. | "copy_referrers", "copy with referrers" |
+| __scan-image__ | Scan one image filesystem with `trivy image`. | "scan images with Trivy" |
+| __scan-sbom__ | Scan one image's per-platform SBOM attestations with `trivy sbom`. | "scan platform SBOMs" |
+| __evaluate-findings__ | Apply the severity threshold + CVE exceptions to produce a gate decision. | "gate on scan findings" |
+| __attach-scan-report__ | Attach the OCI scan-report referrer to a promoted image. | "attach scan-report attestation" |
+| __delete-image__ | Delete one tag from a GHCR repository via the Packages API. | "delete promoted tags from quarantine" |
 
 Standard nouns:
 
@@ -40,9 +40,9 @@ Standard nouns:
 - **tag**, **digest**, **referrers** — as in the OCI spec.
 - **quarantine** — the untrusted landing repository (`quarantine/<image>`).
 - **golden** / **base** — promotion targets for clean images (`golden/<image>`,
-  `base/hardened/<image>`).
+   `base/hardened/<image>`).
 - **decision** — the gate outcome: `promote`, `dryrun`, `blocked`, or
-  `blocked-missing-sbom`.
+   `blocked-missing-sbom`.
 
 ## Action catalogue
 
@@ -147,6 +147,14 @@ Attach an empty OCI scan-report referrer to a promoted image.
 | `scanner-version` | yes | — | Resolved Trivy version. |
 | `method` | no | `image` | Scan method recorded: `image` or `sbom`. |
 | `sbom-predicate-type` | no | `""` | Recorded only when `method` is `sbom`. |
+| `override` | no | `false` | Records a manual override (promoted despite a failing gate). |
+| `override-approver` | no | `""` | Login that approved the override (when `override` is true). |
+| `override-issue` | no | `""` | Tracking-issue URL for the override (when `override` is true). |
+| `override-cves` | no | `""` | Pipe-separated CVEs that were overridden (when `override` is true). |
+| `override` | no | `false` | Records a manual override (promoted despite a failing gate). |
+| `override-approver` | no | `""` | Login that approved the override (when `override` is true). |
+| `override-issue` | no | `""` | Tracking-issue URL for the override (when `override` is true). |
+| `override-cves` | no | `""` | Pipe-separated CVEs that were overridden (when `override` is true). |
 
 The referrer artifact type is `application/vnd.cssc.scan-report.v1+json`; see the
 [promote-from-quarantine architecture](../architecture/workflows/promote-from-quarantine-workflows.md#scan-report-referrer-artifact)
@@ -163,6 +171,57 @@ Delete one tag from a GHCR repository via the Packages REST API.
 | `token` | no | `""` | PAT with `delete:packages`; deletion is skipped when empty. |
 
 Outputs: `status` (`deleted` / `skipped` / `failed`).
+
+### notify-slack
+
+Post an override-event message to a Slack incoming webhook. A no-op (with a
+warning) when `webhook-url` is empty.
+
+| Input | Required | Default | Description |
+| ----- | -------- | ------- | ----------- |
+| `webhook-url` | no | `""` | Slack incoming webhook URL; empty disables the action. |
+| `status` | yes | — | Message template: `blocked-pending`, `approved`, or `denied`. |
+| `image` | yes | — | Source repository. |
+| `tag` | yes | — | Image tag. |
+| `threshold` | no | `""` | Severity threshold the image failed. |
+| `blocking-cves` | no | `""` | Human-readable blocking-CVE summary. |
+| `issue-url` | no | `""` | Link to the tracking issue. |
+| `run-url` | no | `""` | Link to the workflow run. |
+| `approver` | no | `""` | Login recorded for approved/denied messages. |
+
+### manage-issue
+
+Create, update, comment on, close, or read a promotion tracking issue via `gh`
+(needs `issues: write`).
+
+| Input | Required | Default | Description |
+| ----- | -------- | ------- | ----------- |
+| `operation` | yes | — | `open-or-update`, `comment`, `close`, or `get`. |
+| `image` | yes | — | Source repository (dedupe + metadata). |
+| `tag` | yes | — | Image tag (dedupe + metadata). |
+| `metadata-json` | no | `""` | Machine-readable JSON embedded in the body (`open-or-update`). |
+| `body` | no | `""` | Human-readable body / comment text. |
+| `outcome` | no | `""` | `close` only: `promotion-approved` or `promotion-denied`. |
+| `issue-number` | no | `""` | Target issue; resolved by title when empty. |
+| `token` | yes | — | `GITHUB_TOKEN` with `issues: write`. |
+
+Dedupes by the `promotion-pending` label plus a deterministic title
+(`Promotion blocked: <image>:<tag>`). Outputs: `issue-number`, `issue-url`,
+`metadata-json` (parsed back out of an existing issue).
+
+### verify-approver
+
+Verify an actor meets a minimum repository permission before an override is
+honored.
+
+| Input | Required | Default | Description |
+| ----- | -------- | ------- | ----------- |
+| `actor` | yes | — | The login that issued the command. |
+| `min-permission` | no | `maintain` | Minimum permission: `admin`, `maintain`, or `write`. |
+| `fail-on-unauthorized` | no | `true` | Fail the step when the actor is below the threshold. |
+| `token` | yes | — | Token able to read collaborator permissions. |
+
+Outputs: `authorized` (`true` / `false`).
 
 ## How the actions compose
 
@@ -189,9 +248,9 @@ enumerate ──► scan (matrix: one job per tag) ──► summary
 ```
 
 - **enumerate** lists the tags (`enumerate-tags`) and resolves the severity set,
-  emitting a JSON tag array consumed by `strategy.matrix`.
+   emitting a JSON tag array consumed by `strategy.matrix`.
 - **scan** runs once per tag, in parallel (`fail-fast: false`), chaining the
-  single-image actions and uploading a small result artifact.
+   single-image actions and uploading a small result artifact.
 - **summary** downloads every result artifact and renders one aggregated job
-  summary (overview table + per-image detail), so the output matches the old
-  monolithic workflow despite the parallel topology.
+   summary (overview table + per-image detail), so the output matches the old
+   monolithic workflow despite the parallel topology.

--- a/docs/reference/workflow-actions.md
+++ b/docs/reference/workflow-actions.md
@@ -151,10 +151,6 @@ Attach an empty OCI scan-report referrer to a promoted image.
 | `override-approver` | no | `""` | Login that approved the override (when `override` is true). |
 | `override-issue` | no | `""` | Tracking-issue URL for the override (when `override` is true). |
 | `override-cves` | no | `""` | Pipe-separated CVEs that were overridden (when `override` is true). |
-| `override` | no | `false` | Records a manual override (promoted despite a failing gate). |
-| `override-approver` | no | `""` | Login that approved the override (when `override` is true). |
-| `override-issue` | no | `""` | Tracking-issue URL for the override (when `override` is true). |
-| `override-cves` | no | `""` | Pipe-separated CVEs that were overridden (when `override` is true). |
 
 The referrer artifact type is `application/vnd.cssc.scan-report.v1+json`; see the
 [promote-from-quarantine architecture](../architecture/workflows/promote-from-quarantine-workflows.md#scan-report-referrer-artifact)


### PR DESCRIPTION
## Summary

Adds an optional approve/deny override gate to the promote-from-quarantine workflows. When a scanned image fails the CVE threshold and approval is enabled, a tracking issue is filed and a Slack notification is sent; a maintainer can `/approve` or `/deny` via issue comment (or `workflow_dispatch`) to promote the image despite the failing threshold or close it out.

## What's included

**New reusable composite actions**
- `notify-slack` — post Block Kit status messages to a Slack incoming webhook (#65)
- `manage-issue` — idempotent tracking-issue lifecycle (open-or-update / comment / close / get) with embedded JSON metadata as the source of truth (#66)
- `verify-approver` — enforce minimum repo permission for approvers (#67)

**Changes**
- `attach-scan-report` — record `com.cssc.scan.override*` provenance annotations (#68)
- `_promote-from-quarantine.yml` / `_promote-from-quarantine-sbom.yml` — `enable_approval` input + `slack_webhook` secret; file issue + notify Slack on blocked images (#69)
- `_promote-override.yml` (reusable) + `promote-override.yml` (caller) — execute the maintainer decision (#70)
- Docs: design doc, workflow-actions, workflow-naming, workflows overview (#71)

## Design

See [promote-from-quarantine-override-approval.md](docs/architecture/workflows/promote-from-quarantine-override-approval.md).

## Validation

- `get_errors`: clean (only benign `SLACK_WEBHOOK` "Context access might be invalid" until the secret is configured)
- `shellcheck -S warning`: clean on all run blocks
- Issue-body metadata round-trip tested (incl. CRLF handling)

## Before enabling in production

1. Configure repo secrets `SLACK_WEBHOOK` and `GHCR_DELETE_TOKEN`.
2. Opt a per-image caller in via `enable_approval: true` + pass `slack_webhook`. Existing callers are unchanged and backward-compatible.

## Tracking

Closes #64
Closes #65
Closes #66
Closes #67
Closes #68
Closes #69
Closes #70
Closes #71