### PR TITLE
Enable override approval + Slack alerts on all promote callers

### DIFF
--- a/.github/workflows/promote-from-quarantine-hardened-python.yml
+++ b/.github/workflows/promote-from-quarantine-hardened-python.yml
@@ -64,6 +64,7 @@ concurrency:
 permissions:
   contents: read
   packages: write
+  issues: write
 
 jobs:
   promote-from-quarantine-hardened-python:

--- a/.github/workflows/promote-from-quarantine-hardened-python.yml
+++ b/.github/workflows/promote-from-quarantine-hardened-python.yml
@@ -75,5 +75,7 @@ jobs:
       cve_exceptions: ${{ github.event_name == 'workflow_dispatch' && inputs.cve_exceptions || '' }}
       sbom_predicate_type: ${{ github.event_name == 'workflow_dispatch' && inputs.sbom_predicate_type || 'https://cyclonedx.org/bom/v1.6' }}
       dry_run: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run || false }}
+      enable_approval: true
     secrets:
       ghcr_delete_token: ${{ secrets.GHCR_DELETE_TOKEN }}
+      slack_webhook: ${{ secrets.SLACK_WEBHOOK }}

--- a/.github/workflows/promote-from-quarantine-node.yml
+++ b/.github/workflows/promote-from-quarantine-node.yml
@@ -56,5 +56,7 @@ jobs:
       severity_threshold: ${{ github.event_name == 'workflow_dispatch' && inputs.severity_threshold || 'HIGH' }}
       cve_exceptions: ${{ github.event_name == 'workflow_dispatch' && inputs.cve_exceptions || '' }}
       dry_run: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run || false }}
+      enable_approval: true
     secrets:
       ghcr_delete_token: ${{ secrets.GHCR_DELETE_TOKEN }}
+      slack_webhook: ${{ secrets.SLACK_WEBHOOK }}

--- a/.github/workflows/promote-from-quarantine-node.yml
+++ b/.github/workflows/promote-from-quarantine-node.yml
@@ -46,6 +46,7 @@ concurrency:
 permissions:
   contents: read
   packages: write
+  issues: write
 
 jobs:
   promote-from-quarantine-node:

--- a/.github/workflows/promote-from-quarantine-openjdk.yml
+++ b/.github/workflows/promote-from-quarantine-openjdk.yml
@@ -56,5 +56,7 @@ jobs:
       severity_threshold: ${{ github.event_name == 'workflow_dispatch' && inputs.severity_threshold || 'HIGH' }}
       cve_exceptions: ${{ github.event_name == 'workflow_dispatch' && inputs.cve_exceptions || '' }}
       dry_run: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run || false }}
+      enable_approval: true
     secrets:
       ghcr_delete_token: ${{ secrets.GHCR_DELETE_TOKEN }}
+      slack_webhook: ${{ secrets.SLACK_WEBHOOK }}

--- a/.github/workflows/promote-from-quarantine-openjdk.yml
+++ b/.github/workflows/promote-from-quarantine-openjdk.yml
@@ -46,6 +46,7 @@ concurrency:
 permissions:
   contents: read
   packages: write
+  issues: write
 
 jobs:
   promote-from-quarantine-openjdk:

--- a/.github/workflows/promote-from-quarantine-python.yml
+++ b/.github/workflows/promote-from-quarantine-python.yml
@@ -56,5 +56,7 @@ jobs:
       severity_threshold: ${{ github.event_name == 'workflow_dispatch' && inputs.severity_threshold || 'HIGH' }}
       cve_exceptions: ${{ github.event_name == 'workflow_dispatch' && inputs.cve_exceptions || '' }}
       dry_run: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run || false }}
+      enable_approval: true
     secrets:
       ghcr_delete_token: ${{ secrets.GHCR_DELETE_TOKEN }}
+      slack_webhook: ${{ secrets.SLACK_WEBHOOK }}

--- a/.github/workflows/promote-from-quarantine-python.yml
+++ b/.github/workflows/promote-from-quarantine-python.yml
@@ -46,6 +46,7 @@ concurrency:
 permissions:
   contents: read
   packages: write
+  issues: write
 
 jobs:
   promote-from-quarantine-python:


### PR DESCRIPTION
## Summary

Turns on the human-in-the-loop **override approval** path (and its Slack notifications) for **all four** promote-from-quarantine callers:

- promote-from-quarantine-python.yml
- promote-from-quarantine-node.yml
- promote-from-quarantine-openjdk.yml
- promote-from-quarantine-hardened-python.yml (SBOM)

Each caller now sets `enable_approval: true` and forwards the `SLACK_WEBHOOK` secret as `slack_webhook`. No reusable-workflow or action changes — this is configuration only; the underlying capability shipped in #72.

## Behavior change

When an image fails the CVE gate, instead of being silently left in quarantine it now:
1. opens (or refreshes) a `promotion-pending` tracking issue, and
2. posts a Slack `blocked-pending` alert.

A maintainer then comments `/approve` or `/deny` to override or reject. See [docs/guides/configuring-override-approval.md](docs/guides/configuring-override-approval.md).

## Required follow-up (repo admin)

Add the **`SLACK_WEBHOOK`** repository secret (Settings → Secrets and variables → Actions). Until then `notify-slack` no-ops with a warning and the issue is still opened, so nothing breaks.

## Validation

- VS Code `get_errors` clean on all four files (the `SLACK_WEBHOOK` "Context access might be invalid" lint is benign and disappears once the secret exists).