### PR TITLE
Fix override promotion failing on quarantine-delete error

### DIFF
--- a/.github/actions/delete-image/action.yml
+++ b/.github/actions/delete-image/action.yml
@@ -72,6 +72,14 @@ runs:
           exit 0
         fi
 
-        GH_TOKEN="${DELETE_TOKEN}" gh api -X DELETE "${base}/versions/${vid}" >/dev/null
-        echo "Deleted ${REPOSITORY}:${TAG} (version ${vid})."
-        echo "status=deleted" >> "${GITHUB_OUTPUT}"
+        # Deletion is best-effort cleanup: a failure here (e.g. GHCR refusing to
+        # delete the last tagged version of a package, HTTP 400) must not fail
+        # the promotion that already succeeded. Capture the error, warn, and
+        # report status=failed instead of aborting the job.
+        if err="$(GH_TOKEN="${DELETE_TOKEN}" gh api -X DELETE "${base}/versions/${vid}" 2>&1 >/dev/null)"; then
+          echo "Deleted ${REPOSITORY}:${TAG} (version ${vid})."
+          echo "status=deleted" >> "${GITHUB_OUTPUT}"
+        else
+          echo "::warning::Failed to delete ${REPOSITORY}:${TAG} (version ${vid}); leaving it in place. ${err}"
+          echo "status=failed" >> "${GITHUB_OUTPUT}"
+        fi

--- a/.github/actions/delete-image/action.yml
+++ b/.github/actions/delete-image/action.yml
@@ -6,7 +6,9 @@
 # quarantine after it has been promoted.
 #
 # Resolves the owner type (user vs organization) and the package-version id for
-# the tag, then issues the delete. Emits a status the caller can surface:
+# the tag, then issues the delete. When the tag is the package's last tagged
+# version (which GHCR refuses to delete via the versions API), it falls back to
+# deleting the whole package. Emits a status the caller can surface:
 # deleted | skipped | failed.
 #
 # Terminology: see docs/reference/workflow-actions.md.
@@ -72,13 +74,25 @@ runs:
           exit 0
         fi
 
-        # Deletion is best-effort cleanup: a failure here (e.g. GHCR refusing to
-        # delete the last tagged version of a package, HTTP 400) must not fail
-        # the promotion that already succeeded. Capture the error, warn, and
-        # report status=failed instead of aborting the job.
+        # Deletion is best-effort cleanup: a failure here must not fail the
+        # promotion that already succeeded. Capture the error, and:
+        #   - if GHCR refuses because this is the last tagged version of the
+        #     package (HTTP 400), delete the whole package instead — emptying the
+        #     quarantine package is the intended cleanup once its only image was
+        #     promoted;
+        #   - otherwise warn and report status=failed instead of aborting.
         if err="$(GH_TOKEN="${DELETE_TOKEN}" gh api -X DELETE "${base}/versions/${vid}" 2>&1 >/dev/null)"; then
           echo "Deleted ${REPOSITORY}:${TAG} (version ${vid})."
           echo "status=deleted" >> "${GITHUB_OUTPUT}"
+        elif printf '%s' "${err}" | grep -qiF "last tagged version"; then
+          echo "::notice::'${TAG}' is the last tagged version of ${REPOSITORY}; deleting the whole package instead."
+          if perr="$(GH_TOKEN="${DELETE_TOKEN}" gh api -X DELETE "${base}" 2>&1 >/dev/null)"; then
+            echo "Deleted package ${REPOSITORY} (removed last tag '${TAG}')."
+            echo "status=deleted" >> "${GITHUB_OUTPUT}"
+          else
+            echo "::warning::Failed to delete package ${REPOSITORY}; leaving it in place. ${perr}"
+            echo "status=failed" >> "${GITHUB_OUTPUT}"
+          fi
         else
           echo "::warning::Failed to delete ${REPOSITORY}:${TAG} (version ${vid}); leaving it in place. ${err}"
           echo "status=failed" >> "${GITHUB_OUTPUT}"

--- a/.github/workflows/_promote-override.yml
+++ b/.github/workflows/_promote-override.yml
@@ -152,6 +152,7 @@ jobs:
 
       # --- Approve path: promote despite the gate, record the override. --------
       - name: Promote overridden image
+        id: promote
         if: inputs.decision == 'approve'
         uses: ./.github/actions/mirror-image
         with:
@@ -185,8 +186,11 @@ jobs:
           tag: ${{ steps.meta.outputs.tag }}
           token: ${{ secrets.ghcr_delete_token }}
 
+      # Close + notify once the promotion itself has succeeded, regardless of
+      # the optional quarantine-delete outcome (best-effort cleanup must not
+      # leave the tracking issue open after a successful override promotion).
       - name: Close issue as approved
-        if: inputs.decision == 'approve'
+        if: always() && inputs.decision == 'approve' && steps.promote.conclusion == 'success'
         uses: ./.github/actions/manage-issue
         with:
           operation: close
@@ -198,7 +202,7 @@ jobs:
           token: ${{ github.token }}
 
       - name: Notify Slack of approval
-        if: inputs.decision == 'approve'
+        if: always() && inputs.decision == 'approve' && steps.promote.conclusion == 'success'
         uses: ./.github/actions/notify-slack
         with:
           webhook-url: ${{ secrets.slack_webhook }}


### PR DESCRIPTION
## Problem

When approving a blocked promotion via `/approve`, the override run [28305158296](https://github.com/toddysm/cssc-framework/actions/runs/28305158296) **promoted the image successfully** but then **failed** at *Delete overridden tag from quarantine*:

```
gh: You cannot delete the last tagged version of a package.
You must delete the package instead. (HTTP 400)
```

Because the approve-path *Close issue as approved* / *Notify Slack* steps were gated on implicit `success()`, the delete failure **skipped** them — leaving the tracking issue open and no approval notification, even though the promotion had already happened.

## Fixes

1. **[delete-image](.github/actions/delete-image/action.yml) — handle the last-tagged-version case + best-effort deletion.**
   - When GHCR rejects deleting the tag because it is the package's **last tagged version** (HTTP 400), fall back to **deleting the whole package** (`DELETE …/packages/container/<pkg>`) — the intended quarantine cleanup once its only image has been promoted.
   - Any other delete error is captured, logged as a warning, and reported as `status=failed` instead of exiting non-zero, so a cleanup hiccup never aborts a promotion that already succeeded.
   - Shared action, so this also hardens the **scheduled** promote path.

2. **[_promote-override.yml](.github/workflows/_promote-override.yml) — decouple issue close from delete.** *Close issue as approved* and *Notify Slack of approval* now run on `always() && inputs.decision == 'approve' && steps.promote.conclusion == 'success'`, so the issue is closed and the Slack `approved` message is sent whenever the promotion itself succeeded, regardless of the delete outcome.

## Validation

- VS Code `get_errors` clean on both files.
- `actionlint` clean (only pre-existing benign SC2016/SC2129 style notes elsewhere).