### PR TITLE
feat: automatic CI-failure issue filing (workflow_run monitor)

### DIFF
--- a/.github/actions/manage-failure-issue/action.yml
+++ b/.github/actions/manage-failure-issue/action.yml
@@ -1,0 +1,150 @@
+# Composite action: manage-failure-issue
+#
+# Manage the lifecycle of a per-workflow CI-failure tracking issue using the
+# GitHub REST API via `gh` (authenticated with GITHUB_TOKEN; needs
+# `issues: write`). Two operations:
+#
+#   open-or-update - idempotently create the CI-failure issue, or update an
+#                    existing one. Dedupes by the `ci-failure` label plus a
+#                    deterministic title ("CI failure: <workflow>"). On an
+#                    existing issue it appends a comment recording the new failed
+#                    run; otherwise it creates the issue.
+#   close          - resolve the open CI-failure issue for the workflow (by
+#                    title + label) and close it with a recovery comment. A no-op
+#                    when no such issue exists.
+#
+# This is intentionally separate from `manage-issue` (which is specific to the
+# promotion override flow: a different title, label set, and a required embedded
+# metadata block). See
+# docs/architecture/workflows/ci-failure-notifications.md.
+#
+# Terminology: see docs/reference/workflow-actions.md.
+name: manage-failure-issue
+description: Open/update or close a per-workflow CI-failure tracking issue.
+
+inputs:
+  operation:
+    description: "open-or-update | close."
+    required: true
+  workflow:
+    description: "Display name of the workflow whose run failed/recovered (dedupe key)."
+    required: true
+  run-url:
+    description: "Link to the workflow run."
+    required: false
+    default: ""
+  run-number:
+    description: "Run number of the failed/recovered run."
+    required: false
+    default: ""
+  branch:
+    description: "Branch the run executed on."
+    required: false
+    default: ""
+  event:
+    description: "Event that triggered the run (schedule, workflow_dispatch, ...)."
+    required: false
+    default: ""
+  token:
+    description: "GITHUB_TOKEN with issues: write."
+    required: true
+
+outputs:
+  issue-number:
+    description: "The resolved/created issue number (empty if none)."
+    value: ${{ steps.manage.outputs.issue-number }}
+  issue-url:
+    description: "The resolved/created issue URL (empty if none)."
+    value: ${{ steps.manage.outputs.issue-url }}
+
+runs:
+  using: composite
+  steps:
+    - name: Manage CI-failure issue
+      id: manage
+      shell: bash
+      env:
+        GH_TOKEN: "${{ inputs.token }}"
+        GH_REPO: "${{ github.repository }}"
+        OPERATION: "${{ inputs.operation }}"
+        WORKFLOW: "${{ inputs.workflow }}"
+        RUN_URL: "${{ inputs.run-url }}"
+        RUN_NUMBER: "${{ inputs.run-number }}"
+        BRANCH: "${{ inputs.branch }}"
+        EVENT: "${{ inputs.event }}"
+      run: |
+        set -euo pipefail
+        export LC_ALL=C
+
+        label="ci-failure"
+        title="CI failure: ${WORKFLOW}"
+
+        # Ensure the label exists (idempotent; ignore "already exists").
+        gh label create "${label}" --color "b60205" \
+          --description "A monitored workflow run failed" >/dev/null 2>&1 || true
+
+        # Resolve an existing open CI-failure issue by exact title.
+        resolve_number () {
+          gh issue list --state open --label "${label}" \
+            --search "in:title ${title}" --json number,title \
+            --jq ".[] | select(.title == \"${title}\") | .number" 2>/dev/null \
+            | head -n1 || true
+        }
+
+        # One human-readable line describing the run in question.
+        run_line () {
+          local line="Run"
+          [ -n "${RUN_NUMBER}" ] && line="${line} #${RUN_NUMBER}"
+          [ -n "${BRANCH}" ]     && line="${line} on \`${BRANCH}\`"
+          [ -n "${EVENT}" ]      && line="${line} (${EVENT})"
+          [ -n "${RUN_URL}" ]    && line="${line}: ${RUN_URL}"
+          printf '%s' "${line}"
+        }
+
+        out_number=""
+        out_url=""
+
+        case "${OPERATION}" in
+          open-or-update)
+            existing="$(resolve_number)"
+            if [ -n "${existing}" ]; then
+              gh issue comment "${existing}" \
+                --body "Still failing — $(run_line)" >/dev/null
+              out_number="${existing}"
+            else
+              body_file="$(mktemp)"
+              {
+                printf '%s\n\n' "The workflow **${WORKFLOW}** failed."
+                printf '%s\n\n' "$(run_line)"
+                printf '%s\n' "This issue is opened automatically by \`report-ci-failure.yml\` and is updated on each subsequent failure. It will be closed automatically when the workflow next succeeds."
+              } > "${body_file}"
+              url="$(gh issue create --title "${title}" --label "${label}" \
+                     --body-file "${body_file}")"
+              out_url="${url}"
+              out_number="$(printf '%s' "${url}" | sed 's:.*/::')"
+            fi
+            ;;
+
+          close)
+            existing="$(resolve_number)"
+            if [ -z "${existing}" ]; then
+              echo "No open CI-failure issue for '${WORKFLOW}'; nothing to close."
+            else
+              gh issue comment "${existing}" \
+                --body "Recovered — $(run_line). Closing." >/dev/null
+              gh issue close "${existing}" >/dev/null
+              out_number="${existing}"
+            fi
+            ;;
+
+          *)
+            echo "::error::Invalid operation '${OPERATION}' (expected open-or-update|close)"
+            exit 1 ;;
+        esac
+
+        if [ -n "${out_number}" ] && [ -z "${out_url}" ]; then
+          out_url="$(gh issue view "${out_number}" --json url --jq '.url' 2>/dev/null || true)"
+        fi
+
+        echo "issue-number=${out_number}" >> "${GITHUB_OUTPUT}"
+        echo "issue-url=${out_url}" >> "${GITHUB_OUTPUT}"

--- a/.github/actions/manage-failure-issue/action.yml
+++ b/.github/actions/manage-failure-issue/action.yml
@@ -120,6 +120,7 @@ runs:
               } > "${body_file}"
               url="$(gh issue create --title "${title}" --label "${label}" \
                      --body-file "${body_file}")"
+              rm -f "${body_file}"
               out_url="${url}"
               out_number="$(printf '%s' "${url}" | sed 's:.*/::')"
             fi

--- a/.github/actions/notify-slack/action.yml
+++ b/.github/actions/notify-slack/action.yml
@@ -82,15 +82,19 @@ runs:
 
         case "${STATUS}" in
           blocked-pending)
+            [ -n "${IMAGE}" ] && [ -n "${TAG}" ] || { echo "::error::status '${STATUS}' requires 'image' and 'tag'."; exit 1; }
             header=":no_entry: Promotion blocked — approval needed"
             summary="*${IMAGE}:${TAG}* failed the \`${THRESHOLD:-?}\` vulnerability gate." ;;
           approved)
+            [ -n "${IMAGE}" ] && [ -n "${TAG}" ] || { echo "::error::status '${STATUS}' requires 'image' and 'tag'."; exit 1; }
             header=":white_check_mark: Promotion override approved"
             summary="*${IMAGE}:${TAG}* was promoted despite the gate${APPROVER:+ by ${APPROVER}}." ;;
           denied)
+            [ -n "${IMAGE}" ] && [ -n "${TAG}" ] || { echo "::error::status '${STATUS}' requires 'image' and 'tag'."; exit 1; }
             header=":x: Promotion override denied"
             summary="*${IMAGE}:${TAG}* stays in quarantine${APPROVER:+ (denied by ${APPROVER})}." ;;
           ci-failure)
+            [ -n "${WORKFLOW}" ] || { echo "::error::status 'ci-failure' requires 'workflow'."; exit 1; }
             header=":rotating_light: CI failure"
             summary="*${WORKFLOW}* failed." ;;
           *)

--- a/.github/actions/notify-slack/action.yml
+++ b/.github/actions/notify-slack/action.yml
@@ -1,18 +1,18 @@
 # Composite action: notify-slack
 #
-# Post a formatted message to a Slack incoming webhook describing a
-# promote-from-quarantine override event. Three message templates are selected
-# by `status`:
+# Post a formatted message to a Slack incoming webhook. Four message templates
+# are selected by `status`:
 #   blocked-pending - an image failed the gate and awaits an approve/deny.
 #   approved        - an override was approved and the image was promoted.
 #   denied          - an override was denied; the image stays in quarantine.
+#   ci-failure      - a monitored workflow run failed (uses `workflow`).
 #
 # When `webhook-url` is empty the action is a no-op (with a warning) so callers
 # can leave Slack unconfigured without failing.
 #
 # Terminology: see docs/reference/workflow-actions.md.
 name: notify-slack
-description: Post an override-event message to a Slack incoming webhook.
+description: Post a promotion-event or CI-failure message to a Slack incoming webhook.
 
 inputs:
   webhook-url:
@@ -20,14 +20,20 @@ inputs:
     required: false
     default: ""
   status:
-    description: "Message template: blocked-pending | approved | denied."
+    description: "Message template: blocked-pending | approved | denied | ci-failure."
     required: true
   image:
-    description: "Source repository (e.g. ghcr.io/owner/quarantine/python)."
-    required: true
+    description: "Source repository (e.g. ghcr.io/owner/quarantine/python). Unused for ci-failure."
+    required: false
+    default: ""
   tag:
-    description: "Image tag."
-    required: true
+    description: "Image tag. Unused for ci-failure."
+    required: false
+    default: ""
+  workflow:
+    description: "Workflow display name (used by the ci-failure template)."
+    required: false
+    default: ""
   threshold:
     description: "Severity threshold the image failed (optional)."
     required: false
@@ -59,6 +65,7 @@ runs:
         STATUS: "${{ inputs.status }}"
         IMAGE: "${{ inputs.image }}"
         TAG: "${{ inputs.tag }}"
+        WORKFLOW: "${{ inputs.workflow }}"
         THRESHOLD: "${{ inputs.threshold }}"
         BLOCKING_CVES: "${{ inputs.blocking-cves }}"
         ISSUE_URL: "${{ inputs.issue-url }}"
@@ -69,7 +76,7 @@ runs:
         export LC_ALL=C
 
         if [ -z "${WEBHOOK_URL}" ]; then
-          echo "::warning::No Slack webhook configured; skipping ${STATUS} notification for ${IMAGE}:${TAG}."
+          echo "::warning::No Slack webhook configured; skipping ${STATUS} notification."
           exit 0
         fi
 
@@ -83,8 +90,11 @@ runs:
           denied)
             header=":x: Promotion override denied"
             summary="*${IMAGE}:${TAG}* stays in quarantine${APPROVER:+ (denied by ${APPROVER})}." ;;
+          ci-failure)
+            header=":rotating_light: CI failure"
+            summary="*${WORKFLOW}* failed." ;;
           *)
-            echo "::error::Invalid status '${STATUS}' (expected blocked-pending|approved|denied)"; exit 1 ;;
+            echo "::error::Invalid status '${STATUS}' (expected blocked-pending|approved|denied|ci-failure)"; exit 1 ;;
         esac
 
         # Assemble the context line (CVEs / links) from whichever fields are set.

--- a/.github/workflows/report-ci-failure.yml
+++ b/.github/workflows/report-ci-failure.yml
@@ -1,0 +1,90 @@
+# Workflow: report-ci-failure
+#
+# Repository-wide CI-failure monitor. It subscribes to the completion of the
+# mirror, promote-from-quarantine, and promote-override workflows via the
+# `workflow_run` event and, when an observed run concludes in `failure`, opens
+# (or updates) a de-duplicated "CI failure: <workflow>" tracking issue and — when
+# a Slack webhook is configured — posts an alert. When a previously failing
+# workflow next concludes in `success`, the corresponding issue is closed.
+#
+# `workflow_run` always runs this file from the default branch, so the
+# issue-filing logic cannot be modified from a feature branch or fork. It needs
+# only `issues: write`; no registry access or PAT.
+#
+# Note: runs that fail at startup (startup_failure) may not emit `workflow_run`
+# and can therefore be missed; see
+# docs/architecture/workflows/ci-failure-notifications.md.
+name: report / ci-failure
+
+on:
+  workflow_run:
+    workflows:
+      - "mirror / quarantine/python"
+      - "mirror / quarantine/node"
+      - "mirror / quarantine/openjdk"
+      - "mirror / quarantine/hardened/python"
+      - "promote from quarantine / quarantine/python"
+      - "promote from quarantine / quarantine/node"
+      - "promote from quarantine / quarantine/openjdk"
+      - "promote from quarantine / quarantine/hardened/python"
+      - "promote override"
+    types: [completed]
+
+# Serialise events for the same monitored workflow so concurrent completions
+# cannot open duplicate issues; let different workflows proceed independently.
+concurrency:
+  group: report-ci-failure-${{ github.event.workflow_run.name }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  # A monitored run failed: open or refresh its tracking issue and alert Slack.
+  on-failure:
+    if: github.event.workflow_run.conclusion == 'failure'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out actions
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+
+      - name: Open or update CI-failure issue
+        id: issue
+        uses: ./.github/actions/manage-failure-issue
+        with:
+          operation: open-or-update
+          workflow: ${{ github.event.workflow_run.name }}
+          run-url: ${{ github.event.workflow_run.html_url }}
+          run-number: ${{ github.event.workflow_run.run_number }}
+          branch: ${{ github.event.workflow_run.head_branch }}
+          event: ${{ github.event.workflow_run.event }}
+          token: ${{ github.token }}
+
+      - name: Notify Slack of CI failure
+        uses: ./.github/actions/notify-slack
+        with:
+          webhook-url: ${{ secrets.SLACK_WEBHOOK }}
+          status: ci-failure
+          workflow: ${{ github.event.workflow_run.name }}
+          issue-url: ${{ steps.issue.outputs.issue-url }}
+          run-url: ${{ github.event.workflow_run.html_url }}
+
+  # A monitored workflow recovered: close any open CI-failure issue for it.
+  on-recovery:
+    if: github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out actions
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+
+      - name: Close CI-failure issue on recovery
+        uses: ./.github/actions/manage-failure-issue
+        with:
+          operation: close
+          workflow: ${{ github.event.workflow_run.name }}
+          run-url: ${{ github.event.workflow_run.html_url }}
+          run-number: ${{ github.event.workflow_run.run_number }}
+          branch: ${{ github.event.workflow_run.head_branch }}
+          event: ${{ github.event.workflow_run.event }}
+          token: ${{ github.token }}

--- a/docs/architecture/workflows/README.md
+++ b/docs/architecture/workflows/README.md
@@ -2,7 +2,7 @@
 
 Architecture documentation for the GitHub Actions workflows in this repository.
 
-Workflows fall into three categories (see
+Workflows fall into the following categories (see
 [workflow naming conventions](../../contributing/workflow-naming.md)):
 
 | Category | Purpose | Status |
@@ -10,6 +10,7 @@ Workflows fall into three categories (see
 | **Mirror** | Copy / refresh upstream base images from Docker Hub into GHCR | Implemented |
 | **Promote from quarantine** | Scan quarantined images and promote the ones that pass a vulnerability policy into `golden/<image>` (or `base/...` for base/hardened images) | Implemented |
 | **Build** | Build the demo applications under `apps/` on top of mirrored bases | Planned |
+| **Report** | Watch other workflows and file/close CI-failure tracking issues | Implemented |
 
 ## Documents
 
@@ -21,3 +22,7 @@ Workflows fall into three categories (see
   exceptions, promoted into `golden/<image>` (or `base/...` for base/hardened
   images) with a scan-report referrer, and
   removed from quarantine.
+- [CI failure notifications](ci-failure-notifications.md) — how a
+  `workflow_run` monitor opens and closes per-workflow CI-failure tracking
+  issues (and optional Slack alerts) when a monitored workflow run fails or
+  recovers.

--- a/docs/contributing/workflow-naming.md
+++ b/docs/contributing/workflow-naming.md
@@ -14,7 +14,7 @@ both in the file system and in the Actions UI.
 | **Promote from quarantine** | Scan a quarantined image and promote it into its golden/base repository (`golden/<image>`, or `base/...` for base/hardened images) when it passes the vulnerability policy | `promote-from-quarantine-<image>.yml` | `promote from quarantine / quarantine/<image>` | `promote-from-quarantine-<image>` |
 | **Build** | Build an application image on top of a mirrored base | `build-<app>.yml` | `build / <app>` | `build-<app>` |
 | **Promote override** | Act on a maintainer's approve/deny of a blocked image (issue-comment or dispatch) | `promote-override.yml` | `promote override` | `promote-override-<issue>` |
-| **Report** | Watch other workflows and report CI failures as tracking issues | `report-<purpose>.yml` | `report / <subject>` | `report-<purpose>-<subject>` |
+| **Report** | Watch other workflows and report CI failures as tracking issues | `report-<purpose>.yml` | `report / <purpose>` | `report-<purpose>` |
 | **Reusable** | Shared logic invoked by other workflows; never triggered directly | `_<purpose>.yml` (leading underscore) | `_reusable / <purpose>` | n/a |
 | **Composite action** | A single reusable step shared across workflows | `.github/actions/<verb-noun>/action.yml` | `name: <verb-noun>` | n/a |
 

--- a/docs/contributing/workflow-naming.md
+++ b/docs/contributing/workflow-naming.md
@@ -14,13 +14,15 @@ both in the file system and in the Actions UI.
 | **Promote from quarantine** | Scan a quarantined image and promote it into its golden/base repository (`golden/<image>`, or `base/...` for base/hardened images) when it passes the vulnerability policy | `promote-from-quarantine-<image>.yml` | `promote from quarantine / quarantine/<image>` | `promote-from-quarantine-<image>` |
 | **Build** | Build an application image on top of a mirrored base | `build-<app>.yml` | `build / <app>` | `build-<app>` |
 | **Promote override** | Act on a maintainer's approve/deny of a blocked image (issue-comment or dispatch) | `promote-override.yml` | `promote override` | `promote-override-<issue>` |
+| **Report** | Watch other workflows and report CI failures as tracking issues | `report-<purpose>.yml` | `report / <subject>` | `report-<purpose>-<subject>` |
 | **Reusable** | Shared logic invoked by other workflows; never triggered directly | `_<purpose>.yml` (leading underscore) | `_reusable / <purpose>` | n/a |
 | **Composite action** | A single reusable step shared across workflows | `.github/actions/<verb-noun>/action.yml` | `name: <verb-noun>` | n/a |
 
 ### Rules
 
 1. **Verb prefix.** Every workflow filename starts with a category verb:
-   `mirror-`, `promote-from-quarantine-`, `promote-override`, `build-`, or a leading underscore
+   `mirror-`, `promote-from-quarantine-`, `promote-override`, `build-`,
+   `report-`, or a leading underscore
    (`_`) for reusable
    workflows. This groups related workflows together alphabetically and makes
    intent obvious at a glance.
@@ -108,6 +110,17 @@ Build workflows (added later) build the demo applications under `apps/` on top
 of the mirrored base images. They use the `build-<app>.yml` filename and the
 `build / <app>` display name so they remain clearly separate from mirror
 workflows.
+
+## Report workflows
+
+Report workflows watch *other* workflows and turn CI failures into visible,
+de-duplicated tracking issues. There is one repository-wide monitor,
+[`report-ci-failure.yml`](../../.github/workflows/report-ci-failure.yml), that
+subscribes to the mirror, promote-from-quarantine, and promote-override workflows
+via the `workflow_run` event and opens (or, on recovery, closes) a
+`CI failure: <workflow>` issue. It uses the `report-<purpose>.yml` filename and
+the `report / <subject>` display name. See the
+[CI failure notifications design](../architecture/workflows/ci-failure-notifications.md).
 
 ## Composite actions
 

--- a/docs/reference/workflow-actions.md
+++ b/docs/reference/workflow-actions.md
@@ -170,15 +170,16 @@ Outputs: `status` (`deleted` / `skipped` / `failed`).
 
 ### notify-slack
 
-Post an override-event message to a Slack incoming webhook. A no-op (with a
+Post a promotion-event or CI-failure message to a Slack incoming webhook. A no-op (with a
 warning) when `webhook-url` is empty.
 
 | Input | Required | Default | Description |
 | ----- | -------- | ------- | ----------- |
 | `webhook-url` | no | `""` | Slack incoming webhook URL; empty disables the action. |
-| `status` | yes | — | Message template: `blocked-pending`, `approved`, or `denied`. |
-| `image` | yes | — | Source repository. |
-| `tag` | yes | — | Image tag. |
+| `status` | yes | — | Message template: `blocked-pending`, `approved`, `denied`, or `ci-failure`. |
+| `image` | no | `""` | Source repository (unused for `ci-failure`). |
+| `tag` | no | `""` | Image tag (unused for `ci-failure`). |
+| `workflow` | no | `""` | Workflow display name (used by the `ci-failure` template). |
 | `threshold` | no | `""` | Severity threshold the image failed. |
 | `blocking-cves` | no | `""` | Human-readable blocking-CVE summary. |
 | `issue-url` | no | `""` | Link to the tracking issue. |
@@ -218,6 +219,25 @@ honored.
 | `token` | yes | — | Token able to read collaborator permissions. |
 
 Outputs: `authorized` (`true` / `false`).
+
+### manage-failure-issue
+
+Open/update or close a per-workflow **CI-failure** tracking issue via `gh` (needs
+`issues: write`). Deduped by the `ci-failure` label plus the title
+`CI failure: <workflow>`. Separate from `manage-issue`, which is specific to the
+promotion override flow.
+
+| Input | Required | Default | Description |
+| ----- | -------- | ------- | ----------- |
+| `operation` | yes | — | `open-or-update` or `close`. |
+| `workflow` | yes | — | Workflow display name (dedupe key). |
+| `run-url` | no | `""` | Link to the workflow run. |
+| `run-number` | no | `""` | Run number of the failed/recovered run. |
+| `branch` | no | `""` | Branch the run executed on. |
+| `event` | no | `""` | Event that triggered the run. |
+| `token` | yes | — | `GITHUB_TOKEN` with `issues: write`. |
+
+Outputs: `issue-number`, `issue-url`.
 
 ## How the actions compose
 

--- a/docs/reference/workflow-actions.md
+++ b/docs/reference/workflow-actions.md
@@ -177,9 +177,9 @@ warning) when `webhook-url` is empty.
 | ----- | -------- | ------- | ----------- |
 | `webhook-url` | no | `""` | Slack incoming webhook URL; empty disables the action. |
 | `status` | yes | — | Message template: `blocked-pending`, `approved`, `denied`, or `ci-failure`. |
-| `image` | no | `""` | Source repository (unused for `ci-failure`). |
-| `tag` | no | `""` | Image tag (unused for `ci-failure`). |
-| `workflow` | no | `""` | Workflow display name (used by the `ci-failure` template). |
+| `image` | no* | `""` | Source repository. *Required for `blocked-pending`/`approved`/`denied`; unused for `ci-failure`. |
+| `tag` | no* | `""` | Image tag. *Required for the promotion templates; unused for `ci-failure`. |
+| `workflow` | no* | `""` | Workflow display name. *Required for `ci-failure`. |
 | `threshold` | no | `""` | Severity threshold the image failed. |
 | `blocking-cves` | no | `""` | Human-readable blocking-CVE summary. |
 | `issue-url` | no | `""` | Link to the tracking issue. |


### PR DESCRIPTION
Implements the CI-failure notification design (#80) — see [design doc](docs/architecture/workflows/ci-failure-notifications.md).

## What this adds

A repo-wide monitor that turns a failed CI run into a visible, de-duplicated GitHub issue (and an optional Slack alert), and closes it when the workflow recovers.

| Piece | Issue |
| ----- | ----- |
| **[manage-failure-issue](.github/actions/manage-failure-issue/action.yml)** — composite action: open-or-update / close a deduped `CI failure: <workflow>` issue (label `ci-failure`), separate from the promotion-specific `manage-issue`. | #81 |
| **[report-ci-failure.yml](.github/workflows/report-ci-failure.yml)** — `workflow_run` monitor over the 4 mirror + 4 promote-from-quarantine + promote-override workflows. `failure` → open/update; `success` → close. | #82, #83 |
| **[notify-slack](.github/actions/notify-slack/action.yml)** — new `ci-failure` template + `workflow` input (`image`/`tag` now optional); monitor posts a Slack alert on failure. | #84 |
| **Docs** — `Report` category in [workflow-naming.md](docs/contributing/workflow-naming.md), `manage-failure-issue` + `notify-slack` updates in [workflow-actions.md](docs/reference/workflow-actions.md), index row + link in the [architecture README](docs/architecture/workflows/README.md). | #85 |

## Notes

- Needs only `contents: read` + `issues: write`; no PAT. `workflow_run` runs the default-branch definition, so the logic can't be tampered with from forks/branches.
- Slack is optional: `notify-slack` no-ops with a warning when `SLACK_WEBHOOK` is unset.
- **Known limitation (documented):** `startup_failure` runs may not emit `workflow_run` and can be missed; prevention via actionlint/CodeQL/review remains the mitigation for that class.

## Validation

- VS Code `get_errors` clean on all new/changed files.
- `actionlint` clean (only pre-existing benign SC2016/SC2129 elsewhere); `shellcheck -S warning` clean on both action scripts.

Closes #81, closes #82, closes #83, closes #84, closes #85.