### PR TITLE
ci: OCI multi-arch build with manifest + index annotations (#108)

### DIFF
--- a/.github/workflows/build-cssc-dashboard.yml
+++ b/.github/workflows/build-cssc-dashboard.yml
@@ -5,12 +5,14 @@
 # ghcr.io/toddysm/apps/cssc-dashboard/<service>, tagged with the short commit SHA
 # and a moving `latest` tag.
 #
+# Images are OCI, multi-arch (linux/amd64 + linux/arm64), and carry OCI manifest
+# annotations (standard org.opencontainers.image.* + custom com.toddysm.*) at
+# both the index and per-platform manifest scope. `created` is derived from the
+# commit time via SOURCE_DATE_EPOCH so builds are reproducible.
+#
 # Naming convention: "build-<app>.yml" for build workflows, kept separate from
 # "mirror-<image>.yml" and "promote-from-quarantine-<image>.yml". See
 # docs/contributing/workflow-naming.md.
-#
-# NOTE: images are built for the runner's native platform (linux/amd64).
-# Multi-arch (arm64) publishing can be added later with buildx + QEMU.
 name: build / cssc-dashboard
 
 on:
@@ -30,6 +32,9 @@ permissions:
   contents: read
   packages: write
 
+env:
+  BASE_IMAGE: ghcr.io/toddysm/golden/python:3.14-slim
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -44,6 +49,12 @@ jobs:
       - name: Check out
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3
+
+      - name: Set up Buildx
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
+
       - name: Log in to GHCR
         env:
           GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -55,19 +66,72 @@ jobs:
           SERVICE: ${{ matrix.service }}
           IMAGE: ghcr.io/toddysm/apps/cssc-dashboard/${{ matrix.service }}
           SHA: ${{ github.sha }}
+          SERVER_URL: ${{ github.server_url }}
+          REPO: ${{ github.repository }}
+          RUN_ID: ${{ github.run_id }}
+          WORKFLOW: ${{ github.workflow }}
         run: |
           set -euo pipefail
+
           short="${SHA:0:7}"
+
+          # Reproducible timestamps: derive created from the commit time.
+          SOURCE_DATE_EPOCH="$(git log -1 --pretty=%ct)"
+          export SOURCE_DATE_EPOCH
+          created="$(date -u -d "@${SOURCE_DATE_EPOCH}" +%Y-%m-%dT%H:%M:%SZ)"
+
+          # Pin the base image by digest for provenance.
+          base_name="${BASE_IMAGE%:*}"
+          base_tag="${BASE_IMAGE##*:}"
+          base_digest="$(docker buildx imagetools inspect "${BASE_IMAGE}" \
+            --format '{{.Manifest.Digest}}')"
+
+          case "${SERVICE}" in
+            packages-service) desc="Lists GHCR container packages and their tags" ;;
+            issues-service)   desc="Reads promotion tracking issues and blocking CVEs" ;;
+            dashboard-web)    desc="CSSC Dashboard web UI and stage registry (BFF)" ;;
+            *)                desc="CSSC Dashboard service" ;;
+          esac
+
+          # The annotation set (applied at both index and manifest scope below).
+          anns=(
+            "org.opencontainers.image.created=${created}"
+            "org.opencontainers.image.source=${SERVER_URL}/${REPO}"
+            "org.opencontainers.image.revision=${SHA}"
+            "org.opencontainers.image.version=${short}"
+            "org.opencontainers.image.title=CSSC Dashboard ${SERVICE}"
+            "org.opencontainers.image.description=${desc}"
+            "org.opencontainers.image.url=${SERVER_URL}/${REPO}"
+            "org.opencontainers.image.documentation=${SERVER_URL}/${REPO}/blob/main/docs/architecture/apps/cssc-dashboard.md"
+            "org.opencontainers.image.vendor=toddysm.com"
+            "org.opencontainers.image.licenses=Apache-2.0"
+            "org.opencontainers.image.base.name=${base_name}"
+            "org.opencontainers.image.base.digest=${base_digest}"
+            "com.toddysm.image.base.tag=${base_tag}"
+            "com.toddysm.build.workflow=${WORKFLOW}"
+            "com.toddysm.build.run-url=${SERVER_URL}/${REPO}/actions/runs/${RUN_ID}"
+          )
+
+          ann_args=()
+          for a in "${anns[@]}"; do
+            ann_args+=(--annotation "index:${a}" --annotation "manifest:${a}")
+          done
+
           cd apps/python-app
-          docker build \
-            -f "services/${SERVICE}/Dockerfile" \
-            -t "${IMAGE}:${short}" \
-            -t "${IMAGE}:latest" \
+          docker buildx build \
+            --platform linux/amd64,linux/arm64 \
+            --build-arg BASE_IMAGE="${BASE_IMAGE}" \
+            --file "services/${SERVICE}/Dockerfile" \
+            "${ann_args[@]}" \
+            --tag "${IMAGE}:${short}" \
+            --tag "${IMAGE}:latest" \
+            --provenance=false \
+            --sbom=false \
+            --output type=image,oci-mediatypes=true,push=true \
             .
-          docker push "${IMAGE}:${short}"
-          docker push "${IMAGE}:latest"
+
           {
             echo "### ${SERVICE}"
-            echo "- \`${IMAGE}:${short}\`"
-            echo "- \`${IMAGE}:latest\`"
+            echo "- \`${IMAGE}:${short}\` (linux/amd64, linux/arm64)"
+            echo "- base: \`${base_name}:${base_tag}@${base_digest}\`"
           } >> "${GITHUB_STEP_SUMMARY}"

--- a/.github/workflows/build-cssc-dashboard.yml
+++ b/.github/workflows/build-cssc-dashboard.yml
@@ -85,6 +85,9 @@ jobs:
           base_tag="${BASE_IMAGE##*:}"
           base_digest="$(docker buildx imagetools inspect "${BASE_IMAGE}" \
             --format '{{.Manifest.Digest}}')"
+          # Pin the actual build to the base digest, not just annotate it, so
+          # FROM resolves to the exact base image recorded in base.digest.
+          base_ref="${base_name}@${base_digest}"
 
           case "${SERVICE}" in
             packages-service) desc="Lists GHCR container packages and their tags" ;;
@@ -120,7 +123,7 @@ jobs:
           cd apps/python-app
           docker buildx build \
             --platform linux/amd64,linux/arm64 \
-            --build-arg BASE_IMAGE="${BASE_IMAGE}" \
+            --build-arg BASE_IMAGE="${base_ref}" \
             --file "services/${SERVICE}/Dockerfile" \
             "${ann_args[@]}" \
             --tag "${IMAGE}:${short}" \

--- a/docs/reference/README.md
+++ b/docs/reference/README.md
@@ -5,3 +5,4 @@ Reference material and conventions for the `cssc-framework` repository.
 - [Workflow actions and terminology](workflow-actions.md) — the composite-action
   catalogue under `.github/actions/`, the standard terminology (verbs and
   nouns), and how the reusable workflows compose the actions.
+- [Image annotations](image-annotations.md) — OCI manifest annotations carried by the CSSC Dashboard images.

--- a/docs/reference/image-annotations.md
+++ b/docs/reference/image-annotations.md
@@ -48,4 +48,8 @@ crane manifest ghcr.io/toddysm/apps/cssc-dashboard/packages-service:latest | jq 
 ## Reproducibility
 
 `created` and layer timestamps are derived from the commit time via
-`SOURCE_DATE_EPOCH`, so rebuilding the same commit yields the same content.
+`SOURCE_DATE_EPOCH`, which makes those timestamps deterministic, and the build
+pins the base image by digest (`base.digest`). Full bit-for-bit digest
+reproducibility additionally depends on stable dependency resolution (for
+example `pip`), so `SOURCE_DATE_EPOCH` removes timestamp nondeterminism but is
+not a guarantee on its own.

--- a/docs/reference/image-annotations.md
+++ b/docs/reference/image-annotations.md
@@ -1,0 +1,51 @@
+# CSSC Dashboard image annotations
+
+The CSSC Dashboard application images (built by the
+[`build / cssc-dashboard`](../../.github/workflows/build-cssc-dashboard.yml)
+workflow) are **OCI**, **multi-arch** (`linux/amd64`, `linux/arm64`), and carry
+OCI **manifest annotations** so supply-chain metadata travels with the image.
+
+Annotations are set at **both** the multi-arch **index** and each **per-platform
+manifest**, so they are visible regardless of which descriptor a tool inspects:
+
+```bash
+crane manifest ghcr.io/toddysm/apps/cssc-dashboard/packages-service:latest | jq .annotations
+```
+
+## Standard annotations (`org.opencontainers.image.*`)
+
+| Annotation | Value |
+| ---------- | ----- |
+| `created` | Build time derived from the commit time (`SOURCE_DATE_EPOCH`) — reproducible. |
+| `source` | The source repository URL. |
+| `revision` | The full commit SHA the image was built from. |
+| `version` | The image version (short commit SHA). |
+| `title` | `CSSC Dashboard <service>`. |
+| `description` | One-line service description. |
+| `url` | Project URL. |
+| `documentation` | Link to the CSSC Dashboard design doc. |
+| `vendor` | `toddysm.com`. |
+| `licenses` | `Apache-2.0`. |
+| `base.name` | The base image **name only** (e.g. `ghcr.io/toddysm/golden/python`). |
+| `base.digest` | The base image digest the image was built on. |
+
+> **Note on `base.name`.** The OCI image spec defines
+> `org.opencontainers.image.base.name` as the *full* base reference (including
+> the tag). This project deliberately stores the **name only** there and keeps
+> the tag in the custom `com.toddysm.image.base.tag` annotation (below), so the
+> name, tag, and digest are independently addressable. Tools that expect the
+> full reference in `base.name` should compose it as
+> `base.name + ":" + com.toddysm.image.base.tag`.
+
+## Custom annotations (`com.toddysm.*`)
+
+| Annotation | Value |
+| ---------- | ----- |
+| `com.toddysm.image.base.tag` | The base image tag (e.g. `3.14-slim`). |
+| `com.toddysm.build.workflow` | The building workflow display name. |
+| `com.toddysm.build.run-url` | Link to the exact GitHub Actions run. |
+
+## Reproducibility
+
+`created` and layer timestamps are derived from the commit time via
+`SOURCE_DATE_EPOCH`, so rebuilding the same commit yields the same content.


### PR DESCRIPTION
Implements #108 (tracked by #111).

Rebuilds the CSSC Dashboard application images with **docker buildx**:
- **Multi-arch** (linux/amd64 + linux/arm64), OCI media types.
- **OCI manifest annotations** — standard `org.opencontainers.image.*` + custom `com.toddysm.*` — applied at **both** the index and per-platform manifest scope.
- **Reproducible `created`** derived from the commit time (`SOURCE_DATE_EPOCH`).
- Base image **pinned by digest** (`base.name` name-only + `com.toddysm.image.base.tag` + `base.digest`).
- SBOM/provenance intentionally **off** here (`--sbom=false --provenance=false`) — those are #109 / #110.

Docs: adds `docs/reference/image-annotations.md` (linked from the reference index), including the note about the deliberate `base.name` name-only deviation.

Pinned actions: `setup-qemu-action`/`setup-buildx-action` (v3, by SHA). actionlint clean.