### PR TITLE
ci: attach SPDX SBOM to the application images (#109)

### DIFF
--- a/.github/workflows/build-cssc-dashboard.yml
+++ b/.github/workflows/build-cssc-dashboard.yml
@@ -8,7 +8,8 @@
 # Images are OCI, multi-arch (linux/amd64 + linux/arm64), and carry OCI manifest
 # annotations (standard org.opencontainers.image.* + custom com.toddysm.*) at
 # both the index and per-platform manifest scope. `created` is derived from the
-# commit time via SOURCE_DATE_EPOCH so builds are reproducible.
+# commit time via SOURCE_DATE_EPOCH so builds are reproducible. An SPDX SBOM is
+# generated per platform and attached to the image as an OCI referrer.
 #
 # Naming convention: "build-<app>.yml" for build workflows, kept separate from
 # "mirror-<image>.yml" and "promote-from-quarantine-<image>.yml". See
@@ -129,7 +130,7 @@ jobs:
             --tag "${IMAGE}:${short}" \
             --tag "${IMAGE}:latest" \
             --provenance=false \
-            --sbom=false \
+            --sbom=true \
             --output type=image,oci-mediatypes=true,push=true \
             .
 
@@ -137,4 +138,5 @@ jobs:
             echo "### ${SERVICE}"
             echo "- \`${IMAGE}:${short}\` (linux/amd64, linux/arm64)"
             echo "- base: \`${base_name}:${base_tag}@${base_digest}\`"
+            echo "- SBOM: SPDX attestation attached as an OCI referrer"
           } >> "${GITHUB_STEP_SUMMARY}"

--- a/docs/reference/README.md
+++ b/docs/reference/README.md
@@ -6,3 +6,4 @@ Reference material and conventions for the `cssc-framework` repository.
   catalogue under `.github/actions/`, the standard terminology (verbs and
   nouns), and how the reusable workflows compose the actions.
 - [Image annotations](image-annotations.md) — OCI manifest annotations carried by the CSSC Dashboard images.
+- [Image attestations](image-attestations.md) — SBOM (and, later, provenance) attestations attached to the CSSC Dashboard images.

--- a/docs/reference/image-attestations.md
+++ b/docs/reference/image-attestations.md
@@ -1,0 +1,28 @@
+# CSSC Dashboard image attestations
+
+The CSSC Dashboard application images (built by the
+[`build / cssc-dashboard`](../../.github/workflows/build-cssc-dashboard.yml)
+workflow) carry build-time attestations attached as **OCI referrers**, so they
+travel with the image in GHCR and can be discovered without pulling the image.
+
+## SBOM
+
+An **SPDX** Software Bill of Materials is generated **per platform**
+(`linux/amd64`, `linux/arm64`) by BuildKit (`docker buildx build --sbom=true`)
+and attached to the image as an in-toto attestation referrer.
+
+### Retrieve
+
+```bash
+# Inspect the SBOM(s) via buildx:
+docker buildx imagetools inspect \
+  ghcr.io/toddysm/apps/cssc-dashboard/packages-service:latest \
+  --format '{{ json .SBOM }}'
+
+# Or list referrers directly:
+oras discover ghcr.io/toddysm/apps/cssc-dashboard/packages-service:latest
+```
+
+The SBOM complements the vulnerability scanning already performed in the
+promote-from-quarantine flow; here it is produced at application build time and
+describes the final application image contents.


### PR DESCRIPTION
Implements #109 (tracked by #111).

Enables **SBOM generation** in the `build / cssc-dashboard` workflow (`docker buildx build --sbom=true`): each application image gets an **SPDX** SBOM **per platform**, attached as an OCI **referrer** so it travels with the image in GHCR.

- Provenance stays off here (`--provenance=false`) — that's #110.
- Docs: adds `docs/reference/image-attestations.md` (retrieve via `docker buildx imagetools inspect --format '{{ json .SBOM }}'` / `oras discover`).

actionlint clean.