### PR TITLE
ci: attach SLSA build provenance to the application images (#110)

### DIFF
--- a/.github/workflows/build-cssc-dashboard.yml
+++ b/.github/workflows/build-cssc-dashboard.yml
@@ -8,8 +8,9 @@
 # Images are OCI, multi-arch (linux/amd64 + linux/arm64), and carry OCI manifest
 # annotations (standard org.opencontainers.image.* + custom com.toddysm.*) at
 # both the index and per-platform manifest scope. `created` is derived from the
-# commit time via SOURCE_DATE_EPOCH so builds are reproducible. An SPDX SBOM is
-# generated per platform and attached to the image as an OCI referrer.
+# commit time via SOURCE_DATE_EPOCH so builds are reproducible. An SPDX SBOM and
+# a SLSA build-provenance attestation are generated per platform and attached to
+# the image as OCI referrers.
 #
 # Naming convention: "build-<app>.yml" for build workflows, kept separate from
 # "mirror-<image>.yml" and "promote-from-quarantine-<image>.yml". See
@@ -129,7 +130,7 @@ jobs:
             "${ann_args[@]}" \
             --tag "${IMAGE}:${short}" \
             --tag "${IMAGE}:latest" \
-            --provenance=false \
+            --provenance=mode=max \
             --sbom=true \
             --output type=image,oci-mediatypes=true,push=true \
             .
@@ -139,4 +140,5 @@ jobs:
             echo "- \`${IMAGE}:${short}\` (linux/amd64, linux/arm64)"
             echo "- base: \`${base_name}:${base_tag}@${base_digest}\`"
             echo "- SBOM: SPDX attestation attached as an OCI referrer"
+            echo "- Provenance: SLSA build provenance (mode=max) attached as an OCI referrer"
           } >> "${GITHUB_STEP_SUMMARY}"

--- a/docs/reference/image-attestations.md
+++ b/docs/reference/image-attestations.md
@@ -26,3 +26,22 @@ oras discover ghcr.io/toddysm/apps/cssc-dashboard/packages-service:latest
 The SBOM complements the vulnerability scanning already performed in the
 promote-from-quarantine flow; here it is produced at application build time and
 describes the final application image contents.
+
+## Provenance
+
+A **SLSA build-provenance** attestation (`mode=max`) is generated **per
+platform** by BuildKit (`docker buildx build --provenance=mode=max`) and
+attached to the image as an in-toto attestation referrer. It records the
+builder, the source repository and revision, the materials (including the base
+image digest), and the build parameters.
+
+### Retrieve
+
+```bash
+docker buildx imagetools inspect \
+  ghcr.io/toddysm/apps/cssc-dashboard/packages-service:latest \
+  --format '{{ json .Provenance }}'
+```
+
+Together with the manifest annotations (`source`, `revision`, `base.digest`) and
+the SBOM, this gives end-to-end build traceability for each image.


### PR DESCRIPTION
Implements #110 (tracked by #111) — the final item.

Enables **build provenance** in the `build / cssc-dashboard` workflow (`docker buildx build --provenance=mode=max`): each application image gets a **SLSA build-provenance** attestation **per platform**, attached as an OCI **referrer**, recording the builder, source repo + revision, materials (incl. base image digest), and build parameters.

- With #108 (annotations) and #109 (SBOM) already merged, images now carry annotations + SBOM + provenance.
- Docs: adds a Provenance section to `docs/reference/image-attestations.md`.

actionlint clean.