### PR TITLE
Publish SLSA provenance as an OCI 1.1 referrer

### DIFF
--- a/.github/workflows/build-cssc-dashboard.yml
+++ b/.github/workflows/build-cssc-dashboard.yml
@@ -207,8 +207,10 @@ jobs:
           while IFS= read -r pd; do
             [ -n "${pd}" ] || continue
             attach_referrer "${pd}" "https://spdx.dev/Document" "sbom.spdx.json"
+            attach_referrer "${pd}" "https://slsa.dev/provenance/v0.2" "provenance.slsa.json"
           done <<< "${platforms}"
 
           {
             echo "- SBOM: SPDX in-toto statement attached per platform as an OCI 1.1 referrer (\`application/vnd.in-toto+json\`)"
+            echo "- Provenance: SLSA in-toto statement attached per platform as an OCI 1.1 referrer (\`application/vnd.in-toto+json\`)"
           } >> "${GITHUB_STEP_SUMMARY}"


### PR DESCRIPTION
Part of #115. Closes #117.

## What

Exposes the per-platform **SLSA build provenance** (already generated by `docker buildx build --provenance=mode=max`) as a true **OCI 1.1 Referrers-API artifact** on each CSSC Dashboard service image, alongside the SPDX SBOM referrer added in #116.

## How

Extends the referrer-attach step to also attach the layer whose `in-toto.io/predicate-type == https://slsa.dev/provenance/v0.2` via `oras attach --artifact-type application/vnd.in-toto+json`. The `attach_referrer` helper is reused, so both the SBOM and provenance statements are re-published per platform.

## Validation

- `actionlint` clean.
- `shellcheck -S warning` clean on the step.