### PR TITLE
Correct attestation terminology and referrer retrieval docs

### DIFF
--- a/.github/workflows/build-cssc-dashboard.yml
+++ b/.github/workflows/build-cssc-dashboard.yml
@@ -9,8 +9,10 @@
 # annotations (standard org.opencontainers.image.* + custom com.toddysm.*) at
 # both the index and per-platform manifest scope. `created` is derived from the
 # commit time via SOURCE_DATE_EPOCH so builds are reproducible. An SPDX SBOM and
-# a SLSA build-provenance attestation are generated per platform and attached to
-# the image as OCI referrers.
+# a SLSA build-provenance attestation are generated per platform by BuildKit
+# (embedded in the index as attestation-manifests) and then re-published per
+# platform as OCI 1.1 Referrers-API artifacts with `oras attach`, so they are
+# discoverable via `oras discover` / the /v2/.../referrers endpoint.
 #
 # Naming convention: "build-<app>.yml" for build workflows, kept separate from
 # "mirror-<image>.yml" and "promote-from-quarantine-<image>.yml". See

--- a/docs/reference/README.md
+++ b/docs/reference/README.md
@@ -3,7 +3,7 @@
 Reference material and conventions for the `cssc-framework` repository.
 
 - [Workflow actions and terminology](workflow-actions.md) — the composite-action
-  catalogue under `.github/actions/`, the standard terminology (verbs and
-  nouns), and how the reusable workflows compose the actions.
+   catalogue under `.github/actions/`, the standard terminology (verbs and
+   nouns), and how the reusable workflows compose the actions.
 - [Image annotations](image-annotations.md) — OCI manifest annotations carried by the CSSC Dashboard images.
-- [Image attestations](image-attestations.md) — SBOM (and, later, provenance) attestations attached to the CSSC Dashboard images.
+- [Image attestations](image-attestations.md) — SBOM and provenance attestations published as OCI 1.1 referrers on the CSSC Dashboard images.

--- a/docs/reference/image-attestations.md
+++ b/docs/reference/image-attestations.md
@@ -2,25 +2,44 @@
 
 The CSSC Dashboard application images (built by the
 [`build / cssc-dashboard`](../../.github/workflows/build-cssc-dashboard.yml)
-workflow) carry build-time attestations attached as **OCI referrers**, so they
-travel with the image in GHCR and can be discovered without pulling the image.
+workflow) carry build-time attestations that are both **embedded** in the image
+index (as BuildKit attestation-manifests) and **published as OCI 1.1
+Referrers-API artifacts** with `oras attach`. The referrers travel with the
+image in GHCR and are discoverable via the Referrers API (`oras discover`)
+without pulling the image.
+
+> Referrers attach to the **platform** manifest (not the tag/index), so the
+> retrieval commands below target a per-platform digest.
 
 ## SBOM
 
 An **SPDX** Software Bill of Materials is generated **per platform**
 (`linux/amd64`, `linux/arm64`) by BuildKit (`docker buildx build --sbom=true`)
-and attached to the image as an in-toto attestation referrer.
+and published on the platform manifest as an OCI 1.1 referrer (artifact type
+`application/vnd.in-toto+json`, `in-toto.io/predicate-type:
+https://spdx.dev/Document`).
 
 ### Retrieve
 
 ```bash
-# Inspect the SBOM(s) via buildx:
+# Referrers attach to the platform manifest, so resolve the platform digests:
+crane manifest ghcr.io/toddysm/apps/cssc-dashboard/packages-service:latest \
+  | jq -r '.manifests[]
+      | select(.platform.os != "unknown")
+      | "\(.platform.os)/\(.platform.architecture)\t\(.digest)"'
+
+# List the OCI 1.1 referrers attached to a platform manifest:
+oras discover --format tree \
+  ghcr.io/toddysm/apps/cssc-dashboard/packages-service@<platform-digest>
+
+# Pull the SPDX in-toto statement (referrer digest from the step above):
+oras pull -o sbom \
+  ghcr.io/toddysm/apps/cssc-dashboard/packages-service@<referrer-digest>
+
+# Alternatively, read the embedded attestation via buildx:
 docker buildx imagetools inspect \
   ghcr.io/toddysm/apps/cssc-dashboard/packages-service:latest \
   --format '{{ json .SBOM }}'
-
-# Or list referrers directly:
-oras discover ghcr.io/toddysm/apps/cssc-dashboard/packages-service:latest
 ```
 
 The SBOM complements the vulnerability scanning already performed in the
@@ -31,13 +50,23 @@ describes the final application image contents.
 
 A **SLSA build-provenance** attestation (`mode=max`) is generated **per
 platform** by BuildKit (`docker buildx build --provenance=mode=max`) and
-attached to the image as an in-toto attestation referrer. It records the
-builder, the source repository and revision, the materials (including the base
-image digest), and the build parameters.
+published on the platform manifest as an OCI 1.1 referrer (artifact type
+`application/vnd.in-toto+json`, `in-toto.io/predicate-type:
+https://slsa.dev/provenance/v0.2`). It records the builder, the source
+repository and revision, the materials (including the base image digest), and
+the build parameters.
 
 ### Retrieve
 
 ```bash
+# List the referrers on a platform manifest (see the SBOM section for how to
+# resolve <platform-digest>) and pull the SLSA in-toto statement:
+oras discover --format tree \
+  ghcr.io/toddysm/apps/cssc-dashboard/packages-service@<platform-digest>
+oras pull -o provenance \
+  ghcr.io/toddysm/apps/cssc-dashboard/packages-service@<referrer-digest>
+
+# Alternatively, read the embedded attestation via buildx:
 docker buildx imagetools inspect \
   ghcr.io/toddysm/apps/cssc-dashboard/packages-service:latest \
   --format '{{ json .Provenance }}'

--- a/docs/reference/image-attestations.md
+++ b/docs/reference/image-attestations.md
@@ -16,8 +16,7 @@ without pulling the image.
 An **SPDX** Software Bill of Materials is generated **per platform**
 (`linux/amd64`, `linux/arm64`) by BuildKit (`docker buildx build --sbom=true`)
 and published on the platform manifest as an OCI 1.1 referrer (artifact type
-`application/vnd.in-toto+json`, `in-toto.io/predicate-type:
-https://spdx.dev/Document`).
+`application/vnd.in-toto+json`, predicate type `https://spdx.dev/Document`).
 
 ### Retrieve
 
@@ -51,8 +50,8 @@ describes the final application image contents.
 A **SLSA build-provenance** attestation (`mode=max`) is generated **per
 platform** by BuildKit (`docker buildx build --provenance=mode=max`) and
 published on the platform manifest as an OCI 1.1 referrer (artifact type
-`application/vnd.in-toto+json`, `in-toto.io/predicate-type:
-https://slsa.dev/provenance/v0.2`). It records the builder, the source
+`application/vnd.in-toto+json`, predicate type
+`https://slsa.dev/provenance/v0.2`). It records the builder, the source
 repository and revision, the materials (including the base image digest), and
 the build parameters.
 


### PR DESCRIPTION
Part of #115. Closes #118.

## What

Now that the SBOM (#116) and provenance (#117) are published as OCI 1.1 Referrers-API artifacts, this corrects the documentation and workflow prose that previously mislabeled the embedded attestation-manifests as "OCI referrers" and gave a non-working `oras discover <tag>` example.

## Changes

- `docs/reference/image-attestations.md`: intro now explains attestations are both embedded and published as OCI 1.1 referrers; SBOM/Provenance sections document the referrer artifact type + predicate type; retrieval commands use `crane manifest` (resolve per-platform digests) + `oras discover --format tree` + `oras pull`, with `docker buildx imagetools inspect` kept as the embedded alternate.
- `.github/workflows/build-cssc-dashboard.yml`: header comment updated.
- `docs/reference/README.md`: description updated (SBOM + provenance as OCI 1.1 referrers).

## Validation

- `actionlint` clean.