### PR TITLE
Docs: image tagging guide and updated annotations reference

### DIFF
--- a/docs/architecture/workflows/README.md
+++ b/docs/architecture/workflows/README.md
@@ -9,7 +9,7 @@ Workflows fall into the following categories (see
 | -------- | ------- | ------ |
 | **Mirror** | Copy / refresh upstream base images from Docker Hub into GHCR | Implemented |
 | **Promote from quarantine** | Scan quarantined images and promote the ones that pass a vulnerability policy into `golden/<image>` (or `base/...` for base/hardened images) | Implemented |
-| **Build** | Build the demo applications under `apps/` on top of promoted `golden/*` bases and attach supply-chain metadata (annotations, SBOM, provenance); semantic-version tagging is proposed | Implemented |
+| **Build** | Build the demo applications under `apps/` on top of promoted `golden/*` bases, tag them with the semantic-version set (no `latest`), and attach supply-chain metadata (annotations, SBOM, provenance) | Implemented |
 | **Report** | Watch other workflows and file/close CI-failure tracking issues | Implemented |
 
 ## Documents
@@ -27,5 +27,5 @@ Workflows fall into the following categories (see
   issues (and optional Slack alerts) when a monitored workflow run fails or
   recovers.
 - [Build workflows](build-workflows.md) — how the demo applications are built
-  into multi-arch OCI images stamped with annotations, SBOM, and provenance,
-  plus the proposed semantic-version tagging design.
+  into multi-arch OCI images tagged with the semantic-version set and stamped
+  with annotations, SBOM, and provenance.

--- a/docs/architecture/workflows/build-workflows.md
+++ b/docs/architecture/workflows/build-workflows.md
@@ -77,10 +77,6 @@ All third-party actions are pinned by full commit SHA.
 
 ## How are images tagged
 
-> **Status:** proposed. This section is the design for the semver tagging work
-> (tracking issue #123); the current workflow tags images with the short commit
-> SHA and `latest`.
-
 Images are tagged using a **semantic-version** scheme. The version is taken from
 the repository's **code release** (the GitHub Releases page; `0.1.0` at the time
 of writing).
@@ -172,14 +168,10 @@ dependency resolution (for example `pip`).
   `com.toddysm.*`).
 - SPDX SBOM and SLSA provenance, both embedded and published as OCI 1.1
   referrers.
-
-**Proposed (tracking #123)**
-
 - Semantic-version tagging (major/minor/patch/build) sourced from the code
-  release.
-- `version` = immutable build tag; new `com.toddysm.image.lineage` and
+  release, with no `latest` tag.
+- `version` = immutable build tag; `com.toddysm.image.lineage` and
   `com.toddysm.image.tags` annotations.
-- Removal of the `latest` tag.
 
 **Deliberately out of scope**
 

--- a/docs/guides/README.md
+++ b/docs/guides/README.md
@@ -14,3 +14,6 @@ How-to and operational guides for the `cssc-framework` repository.
 - [Reading image annotations](reading-image-annotations.md) —
   how to read the OCI manifest annotations stamped onto each build and what each
   one is used for.
+- [Image tagging](image-tagging.md) —
+  the semantic-version tag set the build publishes, which tag to pin vs. track,
+  the no-`latest` policy, and how to pull by each tag.

--- a/docs/guides/image-tagging.md
+++ b/docs/guides/image-tagging.md
@@ -8,14 +8,14 @@ tag. It is the companion to the
 
 ## The tag set
 
-Every build publishes the same image (a multi-arch OCI index) under **four**
-tags derived from the project's semantic version:
+Every build publishes each service image (a multi-arch OCI index) under the
+same **four** tags derived from the project's semantic version:
 
 | Tag | Example | Mutability | What it points at |
 | --- | --- | --- | --- |
 | `major` | `0` | Moving | The latest build of the current major line. |
 | `minor` | `0.1` | Moving | The latest build of the current minor line. |
-| `patch` | `0.1.0` | Immutable per release | The latest build of that exact release. |
+| `patch` | `0.1.0` | Moving | The latest build of that exact release. |
 | `build` | `0.1.0-69deeec` | Immutable | One specific build (`<release>-<short-sha>`). |
 
 The `build` tag appends the 7-character commit short SHA to the release version,

--- a/docs/guides/image-tagging.md
+++ b/docs/guides/image-tagging.md
@@ -1,0 +1,85 @@
+# Image tagging
+
+This guide explains how the `build / cssc-dashboard` workflow **tags** the CSSC
+Dashboard images, which tag to use for which purpose, and how to pull by each
+tag. It is the companion to the
+[reading image annotations](reading-image-annotations.md) guide and the
+[image annotations reference](../reference/image-annotations.md).
+
+## The tag set
+
+Every build publishes the same image (a multi-arch OCI index) under **four**
+tags derived from the project's semantic version:
+
+| Tag | Example | Mutability | What it points at |
+| --- | --- | --- | --- |
+| `major` | `0` | Moving | The latest build of the current major line. |
+| `minor` | `0.1` | Moving | The latest build of the current minor line. |
+| `patch` | `0.1.0` | Immutable per release | The latest build of that exact release. |
+| `build` | `0.1.0-69deeec` | Immutable | One specific build (`<release>-<short-sha>`). |
+
+The `build` tag appends the 7-character commit short SHA to the release version,
+so it identifies exactly one build and never moves. The `major`, `minor`, and
+`patch` tags are **moving**: each build re-points them at the newest image.
+
+> **No `latest`.** The workflow deliberately does **not** publish a `latest`
+> tag. `latest` is ambiguous (it silently changes and says nothing about the
+> version), so pin one of the tags above instead.
+
+## Where the version comes from
+
+The release version is read from the **latest published GitHub Release** (the
+leading `v` is stripped, so a release tagged `v0.1.0` becomes `0.1.0`). The
+build fails if there is no published release, because the tags cannot be
+derived without one.
+
+## Which tag should I use?
+
+- **Reproducibility / provenance / pinning in manifests** — use the immutable
+  **`build`** tag (`0.1.0-69deeec`). It never changes, so a deployment or lock
+  file always resolves to the exact same image, and it maps 1:1 to a commit.
+- **Track a release line for patches** — use the moving **`patch`** (`0.1.0`)
+  or **`minor`** (`0.1`) tag to pick up rebuilds of the same version (for
+  example a base-image security refresh) without chasing digests.
+- **Always take the newest major build** — use the moving **`major`** (`0`)
+  tag. Convenient for demos, but the least predictable.
+
+The immutable `build` tag is also recorded in the
+`org.opencontainers.image.version` annotation, and the full set is recorded in
+`com.toddysm.image.tags` (see the
+[annotations reference](../reference/image-annotations.md)), so you can recover
+every tag from the image itself.
+
+## Pulling by tag
+
+```bash
+REPO=ghcr.io/toddysm/apps/cssc-dashboard/packages-service
+
+# Exact, immutable build (recommended for pinning):
+docker pull "$REPO:0.1.0-69deeec"
+
+# Latest build of the 0.1 line:
+docker pull "$REPO:0.1"
+
+# Latest build of the current major line:
+docker pull "$REPO:0"
+```
+
+Substitute `issues-service` or `dashboard-web` for the other services.
+
+### Pin by digest for the strongest guarantee
+
+Even an immutable tag is a name; to pin the exact bytes, resolve the digest once
+and reference it:
+
+```bash
+digest="$(crane digest "$REPO:0.1.0-69deeec")"
+docker pull "$REPO@$digest"
+```
+
+## Related
+
+- [Reading image annotations](reading-image-annotations.md)
+- [Verifying image attestations](verifying-image-attestations.md)
+- [Image annotations reference](../reference/image-annotations.md)
+- [Build workflows architecture](../architecture/workflows/build-workflows.md)

--- a/docs/reference/image-annotations.md
+++ b/docs/reference/image-annotations.md
@@ -5,11 +5,14 @@ The CSSC Dashboard application images (built by the
 workflow) are **OCI**, **multi-arch** (`linux/amd64`, `linux/arm64`), and carry
 OCI **manifest annotations** so supply-chain metadata travels with the image.
 
+For how those images are **tagged** (the semantic-version tag set and which
+tag to pin), see the [image tagging guide](../guides/image-tagging.md).
+
 Annotations are set at **both** the multi-arch **index** and each **per-platform
 manifest**, so they are visible regardless of which descriptor a tool inspects:
 
 ```bash
-crane manifest ghcr.io/toddysm/apps/cssc-dashboard/packages-service:latest | jq .annotations
+crane manifest ghcr.io/toddysm/apps/cssc-dashboard/packages-service:0.1 | jq .annotations
 ```
 
 ## Standard annotations (`org.opencontainers.image.*`)
@@ -19,7 +22,7 @@ crane manifest ghcr.io/toddysm/apps/cssc-dashboard/packages-service:latest | jq 
 | `created` | Build time derived from the commit time (`SOURCE_DATE_EPOCH`) — reproducible. |
 | `source` | The source repository URL. |
 | `revision` | The full commit SHA the image was built from. |
-| `version` | The image version (short commit SHA). |
+| `version` | The immutable build tag `<release>-<short-sha>` (e.g. `0.1.0-69deeec`) the image is published under. |
 | `title` | `CSSC Dashboard <service>`. |
 | `description` | One-line service description. |
 | `url` | Project URL. |
@@ -42,6 +45,8 @@ crane manifest ghcr.io/toddysm/apps/cssc-dashboard/packages-service:latest | jq 
 | Annotation | Value |
 | ---------- | ----- |
 | `com.toddysm.image.base.tag` | The base image tag (e.g. `3.14-slim`). |
+| `com.toddysm.image.lineage` | The minor-version lineage the image belongs to (e.g. `0.1`). |
+| `com.toddysm.image.tags` | Every tag applied to the image, `\|`-separated, from `major` to `build` (e.g. `0\|0.1\|0.1.0\|0.1.0-69deeec`). |
 | `com.toddysm.build.workflow` | The building workflow display name. |
 | `com.toddysm.build.run-url` | Link to the exact GitHub Actions run. |
 


### PR DESCRIPTION
Closes #126 (part of #123).

## What changed

- **New** `docs/guides/image-tagging.md` — the semantic-version tag set (`major`/`minor`/`patch`/`build`), which tag to pin (immutable `build`) vs. track (moving `major`/`minor`/`patch`), the no-`latest` policy, where the version comes from (latest GitHub Release), and how to pull by each tag or by digest. Linked from the guides index.
- **Updated** `docs/reference/image-annotations.md` — `version` is now documented as the immutable build tag; added `com.toddysm.image.lineage` and `com.toddysm.image.tags` rows; example uses a semver tag; added a pointer to the tagging guide.
- **Architecture docs** — now that semver tagging is implemented (#125), flipped `build-workflows.md` and the workflows `README.md` from "proposed" to implemented.

> Note: `docs/guides/reading-image-annotations.md` and `docs/guides/verifying-image-attestations.md` already reflect the semver scheme (landed in #122 / PR #130), so this PR focuses on the new tagging guide, the reference doc, and the architecture status flip.