### PR TITLE
build(charts): bump CSSC Dashboard charts to 0.1.1

### DIFF
--- a/apps/python-app/deploy/helm/cssc-dashboard/Chart.yaml
+++ b/apps/python-app/deploy/helm/cssc-dashboard/Chart.yaml
@@ -2,15 +2,15 @@ apiVersion: v2
 name: cssc-dashboard
 description: Umbrella chart for the CSSC Dashboard microservices (packages-service, issues-service, dashboard-web).
 type: application
-version: 0.1.0
-appVersion: "0.1.0"
+version: 0.1.1
+appVersion: "0.1.1"
 dependencies:
   - name: packages-service
-    version: "0.1.0"
+    version: "0.1.1"
     repository: "file://../../../services/packages-service/deploy/helm/packages-service"
   - name: issues-service
-    version: "0.1.0"
+    version: "0.1.1"
     repository: "file://../../../services/issues-service/deploy/helm/issues-service"
   - name: dashboard-web
-    version: "0.1.0"
+    version: "0.1.1"
     repository: "file://../../../services/dashboard-web/deploy/helm/dashboard-web"

--- a/apps/python-app/services/dashboard-web/deploy/helm/dashboard-web/Chart.yaml
+++ b/apps/python-app/services/dashboard-web/deploy/helm/dashboard-web/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: dashboard-web
 description: CSSC Dashboard — dashboard-web
 type: application
-version: 0.1.0
-appVersion: "0.1.0"
+version: 0.1.1
+appVersion: "0.1.1"

--- a/apps/python-app/services/issues-service/deploy/helm/issues-service/Chart.yaml
+++ b/apps/python-app/services/issues-service/deploy/helm/issues-service/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: issues-service
 description: CSSC Dashboard — issues-service
 type: application
-version: 0.1.0
-appVersion: "0.1.0"
+version: 0.1.1
+appVersion: "0.1.1"

--- a/apps/python-app/services/packages-service/deploy/helm/packages-service/Chart.yaml
+++ b/apps/python-app/services/packages-service/deploy/helm/packages-service/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: packages-service
 description: CSSC Dashboard — packages-service
 type: application
-version: 0.1.0
-appVersion: "0.1.0"
+version: 0.1.1
+appVersion: "0.1.1"


### PR DESCRIPTION
Bumps the CSSC Dashboard umbrella and subchart versions (and umbrella dependency constraints) from `0.1.0` to `0.1.1` to align with the v0.1.1 release. Publishing these via `build / cssc-dashboard-charts` pushes the 0.1.1 charts to oci://ghcr.io/toddysm/charts.