### PR TITLE
Build: add security-policy and vulnerability-reporting annotations

### DIFF
--- a/.github/workflows/build-cssc-dashboard.yml
+++ b/.github/workflows/build-cssc-dashboard.yml
@@ -163,6 +163,8 @@ jobs:
             "com.toddysm.image.tags=${major}|${minor}|${patch}|${build}"
             "com.toddysm.build.workflow=${WORKFLOW}"
             "com.toddysm.build.run-url=${SERVER_URL}/${REPO}/actions/runs/${RUN_ID}"
+            "com.toddysm.security.policy=${SERVER_URL}/${REPO}?tab=security-ov-file"
+            "com.toddysm.security.reporturl=${SERVER_URL}/${REPO}/security/advisories/new"
           )
 
           ann_args=()

--- a/.github/workflows/build-cssc-dashboard.yml
+++ b/.github/workflows/build-cssc-dashboard.yml
@@ -164,7 +164,7 @@ jobs:
             "com.toddysm.build.workflow=${WORKFLOW}"
             "com.toddysm.build.run-url=${SERVER_URL}/${REPO}/actions/runs/${RUN_ID}"
             "com.toddysm.security.policy=${SERVER_URL}/${REPO}?tab=security-ov-file"
-            "com.toddysm.security.reporturl=${SERVER_URL}/${REPO}/security/advisories/new"
+            "com.toddysm.security.report-url=${SERVER_URL}/${REPO}/security/advisories/new"
           )
 
           ann_args=()

--- a/docs/guides/build/reading-image-annotations.md
+++ b/docs/guides/build/reading-image-annotations.md
@@ -140,7 +140,7 @@ architecture.
 | `com.toddysm.build.workflow` | Building workflow display name | Which workflow produced the image; auditing the build path. |
 | `com.toddysm.build.run-url` | Link to the exact GitHub Actions run | Jump straight to the CI run that built the image for logs and provenance. |
 | `com.toddysm.security.policy` | Link to the repository security policy | Find out how vulnerabilities in the image are handled and disclosed. |
-| `com.toddysm.security.reporturl` | URL for reporting a vulnerability | Report a vulnerability programmatically (the GitHub private advisory intake). |
+| `com.toddysm.security.report-url` | URL for reporting a vulnerability | Report a vulnerability programmatically (the GitHub private advisory intake). |
 
 ## Worked examples
 

--- a/docs/guides/build/reading-image-annotations.md
+++ b/docs/guides/build/reading-image-annotations.md
@@ -139,6 +139,8 @@ architecture.
 | `com.toddysm.image.tags` | Every tag applied to the image, `\|`-separated (e.g. `0\|0.1\|0.1.0\|0.1.0-69deeec`) | The full tag set the build published, from most-moving (`major`) to immutable (`build`); recover every tag from the image itself. |
 | `com.toddysm.build.workflow` | Building workflow display name | Which workflow produced the image; auditing the build path. |
 | `com.toddysm.build.run-url` | Link to the exact GitHub Actions run | Jump straight to the CI run that built the image for logs and provenance. |
+| `com.toddysm.security.policy` | Link to the repository security policy | Find out how vulnerabilities in the image are handled and disclosed. |
+| `com.toddysm.security.reporturl` | URL for reporting a vulnerability | Report a vulnerability programmatically (the GitHub private advisory intake). |
 
 ## Worked examples
 

--- a/docs/reference/image-annotations.md
+++ b/docs/reference/image-annotations.md
@@ -49,6 +49,8 @@ crane manifest ghcr.io/toddysm/apps/cssc-dashboard/packages-service:0.1 | jq .an
 | `com.toddysm.image.tags` | Every tag applied to the image, `\|`-separated, from `major` to `build` (e.g. `0\|0.1\|0.1.0\|0.1.0-69deeec`). |
 | `com.toddysm.build.workflow` | The building workflow display name. |
 | `com.toddysm.build.run-url` | Link to the exact GitHub Actions run. |
+| `com.toddysm.security.policy` | Link to the repository security policy (how vulnerabilities are handled). |
+| `com.toddysm.security.reporturl` | URL for reporting a vulnerability programmatically (the GitHub private advisory intake). |
 
 ## Reproducibility
 

--- a/docs/reference/image-annotations.md
+++ b/docs/reference/image-annotations.md
@@ -50,7 +50,7 @@ crane manifest ghcr.io/toddysm/apps/cssc-dashboard/packages-service:0.1 | jq .an
 | `com.toddysm.build.workflow` | The building workflow display name. |
 | `com.toddysm.build.run-url` | Link to the exact GitHub Actions run. |
 | `com.toddysm.security.policy` | Link to the repository security policy (how vulnerabilities are handled). |
-| `com.toddysm.security.reporturl` | URL for reporting a vulnerability programmatically (the GitHub private advisory intake). |
+| `com.toddysm.security.report-url` | URL for reporting a vulnerability programmatically (the GitHub private advisory intake). |
 
 ## Reproducibility
 


### PR DESCRIPTION
## Summary
Implements #134 — adds two custom OCI annotations to the CSSC Dashboard service images so the security policy and the vulnerability-reporting endpoint travel with the image metadata.

## Changes
- `build-cssc-dashboard.yml`: two new annotations in the shared annotation set (applied at **both** index and per-platform manifest scope):
  - `com.toddysm.security.policy` = `${SERVER_URL}/${REPO}?tab=security-ov-file` (the repository security policy).
  - `com.toddysm.security.reporturl` = `${SERVER_URL}/${REPO}/security/advisories/new` (programmatic vulnerability-report intake).
- `docs/reference/image-annotations.md`: documented both in the custom-annotations table.
- `docs/guides/build/reading-image-annotations.md`: documented both in the guide table.

URLs are built from the existing `SERVER_URL`/`REPO` env vars for portability. actionlint clean; VS Code get_errors clean.

Closes #134.