### PR TITLE
Fix build: pass --disable-path-validation to oras attach

### DIFF
--- a/.github/workflows/build-cssc-dashboard.yml
+++ b/.github/workflows/build-cssc-dashboard.yml
@@ -241,6 +241,7 @@ jobs:
               --artifact-type application/vnd.in-toto+json \
               --annotation "in-toto.io/predicate-type=${pt}" \
               --annotation "org.opencontainers.image.title=${title}" \
+              --disable-path-validation \
               "${IMAGE}@${pd}" \
               "${work}/${title}:application/vnd.in-toto+json"
             echo "attached ${pt} referrer to ${IMAGE}@${pd}"


### PR DESCRIPTION
## Problem
The `build / cssc-dashboard` run [28605221190](https://github.com/toddysm/cssc-framework/actions/runs/28605221190) failed for all three services at the **Publish attestations as OCI 1.1 referrers** step with:

```
Error: absolute file path detected. If it's intentional, use --disable-path-validation flag to skip this check: /tmp/tmp.XXXXXX/sbom.spdx.json
```

Current `oras` rejects the absolute temp-file path passed to `oras attach`. The step code was unchanged, so this is an `oras` path-validation behavior change.

## Fix
Add `--disable-path-validation` to the `oras attach` invocation. The file lives in an intentional `mktemp -d` directory we control, so skipping the check is safe.

actionlint clean.